### PR TITLE
cmd/compile: add atomix intrinsics with ARM64 runtime LSE detection

### DIFF
--- a/src/cmd/compile/internal/amd64/ssa.go
+++ b/src/cmd/compile/internal/amd64/ssa.go
@@ -1570,6 +1570,8 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 	case ssa.OpAMD64REPMOVSQ:
 		s.Prog(x86.AREP)
 		s.Prog(x86.AMOVSQ)
+	case ssa.OpAMD64MFENCE:
+		s.Prog(x86.AMFENCE)
 	case ssa.OpAMD64LoweredNilCheck:
 		// Issue a load which will fault if the input is nil.
 		// TODO: We currently use the 2-byte instruction TESTB AX, (reg).
@@ -1624,7 +1626,22 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		p = s.Prog(x86.ASETEQ)
 		p.To.Type = obj.TYPE_REG
 		p.To.Reg = v.Reg0()
-	case ssa.OpAMD64ANDBlock, ssa.OpAMD64ANDLlock, ssa.OpAMD64ANDQlock, ssa.OpAMD64ORBlock, ssa.OpAMD64ORLlock, ssa.OpAMD64ORQlock:
+	case ssa.OpAMD64CMPXCHGLlockValue, ssa.OpAMD64CMPXCHGQlockValue:
+		// Atomic compare-and-exchange returning old value.
+		// AX contains expected value on entry, and old memory value on exit.
+		if v.Args[1].Reg() != x86.REG_AX {
+			v.Fatalf("input[1] not in AX %s", v.LongString())
+		}
+		s.Prog(x86.ALOCK)
+		p := s.Prog(v.Op.Asm())
+		p.From.Type = obj.TYPE_REG
+		p.From.Reg = v.Args[2].Reg()
+		p.To.Type = obj.TYPE_MEM
+		p.To.Reg = v.Args[0].Reg()
+		ssagen.AddAux(&p.To, v)
+		// After CMPXCHG, AX contains the old value from memory.
+		// The register allocator ensures v.Reg0() == x86.REG_AX (via cmpxchgValue regInfo).
+	case ssa.OpAMD64ANDBlock, ssa.OpAMD64ANDLlock, ssa.OpAMD64ANDQlock, ssa.OpAMD64ORBlock, ssa.OpAMD64ORLlock, ssa.OpAMD64ORQlock, ssa.OpAMD64XORLlock, ssa.OpAMD64XORQlock:
 		// Atomic memory operations that don't need to return the old value.
 		s.Prog(x86.ALOCK)
 		p := s.Prog(v.Op.Asm())
@@ -1633,7 +1650,7 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		p.To.Type = obj.TYPE_MEM
 		p.To.Reg = v.Args[0].Reg()
 		ssagen.AddAux(&p.To, v)
-	case ssa.OpAMD64LoweredAtomicAnd64, ssa.OpAMD64LoweredAtomicOr64, ssa.OpAMD64LoweredAtomicAnd32, ssa.OpAMD64LoweredAtomicOr32:
+	case ssa.OpAMD64LoweredAtomicAnd64, ssa.OpAMD64LoweredAtomicOr64, ssa.OpAMD64LoweredAtomicAnd32, ssa.OpAMD64LoweredAtomicOr32, ssa.OpAMD64LoweredAtomicXor64, ssa.OpAMD64LoweredAtomicXor32:
 		// Atomic memory operations that need to return the old value.
 		// We need to do these with compare-and-exchange to get access to the old value.
 		// loop:
@@ -1649,6 +1666,8 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		switch v.Op {
 		case ssa.OpAMD64LoweredAtomicOr64:
 			op = x86.AORQ
+		case ssa.OpAMD64LoweredAtomicXor64:
+			op = x86.AXORQ
 		case ssa.OpAMD64LoweredAtomicAnd32:
 			mov = x86.AMOVL
 			op = x86.AANDL
@@ -1656,6 +1675,10 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		case ssa.OpAMD64LoweredAtomicOr32:
 			mov = x86.AMOVL
 			op = x86.AORL
+			cmpxchg = x86.ACMPXCHGL
+		case ssa.OpAMD64LoweredAtomicXor32:
+			mov = x86.AMOVL
+			op = x86.AXORL
 			cmpxchg = x86.ACMPXCHGL
 		}
 		addr := v.Args[0].Reg()

--- a/src/cmd/compile/internal/arm64/ssa.go
+++ b/src/cmd/compile/internal/arm64/ssa.go
@@ -554,6 +554,24 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		ssagen.AddAux(&p.From, v)
 		p.To.Type = obj.TYPE_REG
 		p.To.Reg = v.Reg0()
+	case ssa.OpARM64LoweredAtomicLoad8Relaxed,
+		ssa.OpARM64LoweredAtomicLoad32Relaxed,
+		ssa.OpARM64LoweredAtomicLoad64Relaxed:
+		// Relaxed atomic loads use plain MOV (no acquire semantics).
+		p := s.Prog(v.Op.Asm())
+		p.From.Type = obj.TYPE_MEM
+		p.From.Reg = v.Args[0].Reg()
+		p.To.Type = obj.TYPE_REG
+		p.To.Reg = v.Reg0()
+	case ssa.OpARM64LoweredAtomicStore8Relaxed,
+		ssa.OpARM64LoweredAtomicStore32Relaxed,
+		ssa.OpARM64LoweredAtomicStore64Relaxed:
+		// Relaxed atomic stores use plain MOV (no release semantics).
+		p := s.Prog(v.Op.Asm())
+		p.From.Type = obj.TYPE_REG
+		p.From.Reg = v.Args[1].Reg()
+		p.To.Type = obj.TYPE_MEM
+		p.To.Reg = v.Args[0].Reg()
 	case ssa.OpARM64MOVBstore,
 		ssa.OpARM64MOVHstore,
 		ssa.OpARM64MOVWstore,
@@ -829,23 +847,108 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		p3.To.Type = obj.TYPE_REG
 		p3.To.Reg = out
 
+	case ssa.OpARM64LoweredAtomicCax64,
+		ssa.OpARM64LoweredAtomicCax32:
+		// Atomic compare-and-exchange returning old value (LL/SC version).
+		// LDAXR	(Rarg0), Rout
+		// CMP		Rarg1, Rout
+		// BNE		3(PC)
+		// STLXR	Rarg2, (Rarg0), Rtmp
+		// CBNZ		Rtmp, -4(PC)
+		ld := arm64.ALDAXR
+		st := arm64.ASTLXR
+		cmp := arm64.ACMP
+		if v.Op == ssa.OpARM64LoweredAtomicCax32 {
+			ld = arm64.ALDAXRW
+			st = arm64.ASTLXRW
+			cmp = arm64.ACMPW
+		}
+		r0 := v.Args[0].Reg()
+		r1 := v.Args[1].Reg()
+		r2 := v.Args[2].Reg()
+		out := v.Reg0()
+		p := s.Prog(ld)
+		p.From.Type = obj.TYPE_MEM
+		p.From.Reg = r0
+		p.To.Type = obj.TYPE_REG
+		p.To.Reg = out
+		p1 := s.Prog(cmp)
+		p1.From.Type = obj.TYPE_REG
+		p1.From.Reg = r1
+		p1.Reg = out
+		p2 := s.Prog(arm64.ABNE)
+		p2.To.Type = obj.TYPE_BRANCH
+		p3 := s.Prog(st)
+		p3.From.Type = obj.TYPE_REG
+		p3.From.Reg = r2
+		p3.To.Type = obj.TYPE_MEM
+		p3.To.Reg = r0
+		p3.RegTo2 = arm64.REGTMP
+		p4 := s.Prog(arm64.ACBNZ)
+		p4.From.Type = obj.TYPE_REG
+		p4.From.Reg = arm64.REGTMP
+		p4.To.Type = obj.TYPE_BRANCH
+		p4.To.SetTarget(p)
+		// BNE jumps here - old value is already in out register
+		p5 := s.Prog(obj.ANOP)
+		p2.To.SetTarget(p5)
+
+	case ssa.OpARM64LoweredAtomicCax64Variant,
+		ssa.OpARM64LoweredAtomicCax32Variant:
+		// Atomic compare-and-exchange returning old value (LSE version).
+		// Rarg0: ptr
+		// Rarg1: old
+		// Rarg2: new
+		// MOV  	Rarg1, Rout
+		// CASAL	Rout, (Rarg0), Rarg2
+		// Rout now contains old value
+		cas := arm64.ACASALD
+		mov := arm64.AMOVD
+		if v.Op == ssa.OpARM64LoweredAtomicCax32Variant {
+			cas = arm64.ACASALW
+			mov = arm64.AMOVW
+		}
+		r0 := v.Args[0].Reg()
+		r1 := v.Args[1].Reg()
+		r2 := v.Args[2].Reg()
+		out := v.Reg0()
+
+		// MOV  	Rarg1, Rout
+		p := s.Prog(mov)
+		p.From.Type = obj.TYPE_REG
+		p.From.Reg = r1
+		p.To.Type = obj.TYPE_REG
+		p.To.Reg = out
+
+		// CASAL	Rout, (Rarg0), Rarg2
+		// After CASAL, Rout contains the old value read from memory
+		p1 := s.Prog(cas)
+		p1.From.Type = obj.TYPE_REG
+		p1.From.Reg = out
+		p1.To.Type = obj.TYPE_MEM
+		p1.To.Reg = r0
+		p1.RegTo2 = r2
+
 	case ssa.OpARM64LoweredAtomicAnd64,
 		ssa.OpARM64LoweredAtomicOr64,
+		ssa.OpARM64LoweredAtomicXor64,
 		ssa.OpARM64LoweredAtomicAnd32,
 		ssa.OpARM64LoweredAtomicOr32,
+		ssa.OpARM64LoweredAtomicXor32,
 		ssa.OpARM64LoweredAtomicAnd8,
-		ssa.OpARM64LoweredAtomicOr8:
+		ssa.OpARM64LoweredAtomicOr8,
+		ssa.OpARM64LoweredAtomicXor8:
 		// LDAXR[BW] (Rarg0), Rout
 		// AND/OR	Rarg1, Rout, tmp1
 		// STLXR[BW] tmp1, (Rarg0), Rtmp
 		// CBNZ		Rtmp, -3(PC)
 		ld := arm64.ALDAXR
 		st := arm64.ASTLXR
-		if v.Op == ssa.OpARM64LoweredAtomicAnd32 || v.Op == ssa.OpARM64LoweredAtomicOr32 {
+		if v.Op == ssa.OpARM64LoweredAtomicAnd32 || v.Op == ssa.OpARM64LoweredAtomicOr32 || v.Op == ssa.OpARM64LoweredAtomicXor32 {
 			ld = arm64.ALDAXRW
 			st = arm64.ASTLXRW
 		}
-		if v.Op == ssa.OpARM64LoweredAtomicAnd8 || v.Op == ssa.OpARM64LoweredAtomicOr8 {
+		if v.Op == ssa.OpARM64LoweredAtomicAnd8 || v.Op == ssa.OpARM64LoweredAtomicOr8 || v.Op == ssa.OpARM64LoweredAtomicXor8 {
 			ld = arm64.ALDAXRB
 			st = arm64.ASTLXRB
 		}
@@ -921,6 +1024,28 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 
 		// LDORAL[BDW]  Rarg1, (Rarg0), Rout
 		p := s.Prog(atomic_or)
+		p.From.Type = obj.TYPE_REG
+		p.From.Reg = r1
+		p.To.Type = obj.TYPE_MEM
+		p.To.Reg = r0
+		p.RegTo2 = out
+
+	case ssa.OpARM64LoweredAtomicXor8Variant,
+		ssa.OpARM64LoweredAtomicXor32Variant,
+		ssa.OpARM64LoweredAtomicXor64Variant:
+		atomic_eor := arm64.ALDEORALD
+		if v.Op == ssa.OpARM64LoweredAtomicXor32Variant {
+			atomic_eor = arm64.ALDEORALW
+		}
+		if v.Op == ssa.OpARM64LoweredAtomicXor8Variant {
+			atomic_eor = arm64.ALDEORALB
+		}
+		r0 := v.Args[0].Reg()
+		r1 := v.Args[1].Reg()
+		out := v.Reg0()
+
+		// LDEORAL[BDW]  Rarg1, (Rarg0), Rout
+		p := s.Prog(atomic_eor)
 		p.From.Type = obj.TYPE_REG
 		p.From.Reg = r1
 		p.To.Type = obj.TYPE_MEM

--- a/src/cmd/compile/internal/ssa/_gen/AMD64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/AMD64.rules
@@ -504,6 +504,18 @@
 (AtomicStore64 ptr val mem) => (Select1 (XCHGQ <types.NewTuple(typ.UInt64,types.TypeMem)> val ptr mem))
 (AtomicStorePtrNoWB ptr val mem) => (Select1 (XCHGQ <types.NewTuple(typ.BytePtr,types.TypeMem)> val ptr mem))
 
+// Relaxed atomic loads.  Same as regular atomic loads on x86 (TSO provides sufficient ordering).
+(AtomicLoad8Relaxed ptr mem) => (MOVBatomicload ptr mem)
+(AtomicLoad32Relaxed ptr mem) => (MOVLatomicload ptr mem)
+(AtomicLoad64Relaxed ptr mem) => (MOVQatomicload ptr mem)
+(AtomicLoadPtrRelaxed ptr mem) => (MOVQatomicload ptr mem)
+
+// Relaxed atomic stores.  Use plain MOV (no XCHG needed for relaxed semantics on x86).
+(AtomicStore8Relaxed ptr val mem) => (MOVBstore ptr val mem)
+(AtomicStore32Relaxed ptr val mem) => (MOVLstore ptr val mem)
+(AtomicStore64Relaxed ptr val mem) => (MOVQstore ptr val mem)
+(AtomicStorePtrRelaxedNoWB ptr val mem) => (MOVQstore ptr val mem)
+
 // Atomic exchanges.
 (AtomicExchange8 ptr val mem) => (XCHGB val ptr mem)
 (AtomicExchange32 ptr val mem) => (XCHGL val ptr mem)
@@ -521,6 +533,10 @@
 (AtomicCompareAndSwap32 ptr old new_ mem) => (CMPXCHGLlock ptr old new_ mem)
 (AtomicCompareAndSwap64 ptr old new_ mem) => (CMPXCHGQlock ptr old new_ mem)
 
+// Atomic compare and exchange (returns old value).
+(AtomicCompareAndExchange32 ptr old new_ mem) => (CMPXCHGLlockValue ptr old new_ mem)
+(AtomicCompareAndExchange64 ptr old new_ mem) => (CMPXCHGQlockValue ptr old new_ mem)
+
 // Atomic memory logical operations (old style).
 (AtomicAnd8  ptr val mem) => (ANDBlock ptr val mem)
 (AtomicAnd32 ptr val mem) => (ANDLlock ptr val mem)
@@ -528,10 +544,13 @@
 (AtomicOr32  ptr val mem) => (ORLlock  ptr val mem)
 
 // Atomic memory logical operations (new style).
-(Atomic(And64|And32|Or64|Or32)value ptr val mem) => (LoweredAtomic(And64|And32|Or64|Or32) ptr val mem)
+(Atomic(And64|And32|Or64|Or32|Xor64|Xor32)value ptr val mem) => (LoweredAtomic(And64|And32|Or64|Or32|Xor64|Xor32) ptr val mem)
 
 // Write barrier.
 (WB ...) => (LoweredWB ...)
+
+// MFENCE fence coalescing (duplicate elimination).
+(MFENCE (MFENCE mem)) => (MFENCE mem)
 
 (PanicBounds ...) => (LoweredPanicBoundsRR ...)
 (LoweredPanicBoundsRR [kind] x (MOVQconst [c]) mem) => (LoweredPanicBoundsRC [kind] x {PanicBoundsC{C:c}} mem)
@@ -1460,6 +1479,10 @@
 	(CMPXCHGQlock [off1+off2] {sym} ptr old new_ mem)
 (CMPXCHGLlock [off1] {sym} (ADDQconst [off2] ptr) old new_ mem) && is32Bit(int64(off1)+int64(off2)) =>
 	(CMPXCHGLlock [off1+off2] {sym} ptr old new_ mem)
+(CMPXCHGQlockValue [off1] {sym} (ADDQconst [off2] ptr) old new_ mem) && is32Bit(int64(off1)+int64(off2)) =>
+	(CMPXCHGQlockValue [off1+off2] {sym} ptr old new_ mem)
+(CMPXCHGLlockValue [off1] {sym} (ADDQconst [off2] ptr) old new_ mem) && is32Bit(int64(off1)+int64(off2)) =>
+	(CMPXCHGLlockValue [off1+off2] {sym} ptr old new_ mem)
 
 // We don't need the conditional move if we know the arg of BSF is not zero.
 (CMOVQEQ x _ (Select1 (BS(F|R)Q (ORQconst [c] _)))) && c != 0 => x
@@ -1646,7 +1669,7 @@
 ((SHL|SHR|SAR)XLload [off] {sym} ptr (MOVLconst [c]) mem) => ((SHL|SHR|SAR)Lconst [int8(c&31)] (MOVLload [off] {sym} ptr mem))
 
 // Convert atomic logical operations to easier ones if we don't use the result.
-(Select1 a:(LoweredAtomic(And64|And32|Or64|Or32) ptr val mem)) && a.Uses == 1 && clobber(a) => ((ANDQ|ANDL|ORQ|ORL)lock ptr val mem)
+(Select1 a:(LoweredAtomic(And64|And32|Or64|Or32|Xor64|Xor32) ptr val mem)) && a.Uses == 1 && clobber(a) => ((ANDQ|ANDL|ORQ|ORL|XORQ|XORL)lock ptr val mem)
 
 // If we are checking the results of an add, use the flags directly from the add.
 // Note that this only works for EQ/NE. ADD sets the CF/OF flags differently

--- a/src/cmd/compile/internal/ssa/_gen/AMD64Ops.go
+++ b/src/cmd/compile/internal/ssa/_gen/AMD64Ops.go
@@ -190,6 +190,7 @@ func init() {
 		gpstoreconstidx = regInfo{inputs: []regMask{gpspsbg, gpsp, 0}}
 		gpstorexchg     = regInfo{inputs: []regMask{gp, gpspsbg, 0}, outputs: []regMask{gp}}
 		cmpxchg         = regInfo{inputs: []regMask{gp, ax, gp, 0}, outputs: []regMask{gp, 0}, clobbers: ax}
+		cmpxchgValue    = regInfo{inputs: []regMask{gp, ax, gp, 0}, outputs: []regMask{ax, 0}} // Returns old value in AX
 		atomicLogic     = regInfo{inputs: []regMask{gp &^ ax, gp &^ ax, 0}, outputs: []regMask{ax, 0}}
 
 		fp01        = regInfo{inputs: nil, outputs: fponly}
@@ -1120,6 +1121,9 @@ func init() {
 
 		{name: "LoweredHasCPUFeature", argLength: 0, reg: gp01, rematerializeable: true, typ: "UInt64", aux: "Sym", symEffect: "None"},
 
+		// Memory fence for sequential consistency
+		{name: "MFENCE", argLength: 1, asm: "MFENCE", hasSideEffects: true}, // arg0=mem, returns void
+
 		// LoweredPanicBoundsRR takes x and y, two values that caused a bounds check to fail.
 		// the RC and CR versions are used when one of the arguments is a constant. CC is used
 		// when both are constant (normally both 0, as prove derives the fact that a [0] bounds
@@ -1189,6 +1193,10 @@ func init() {
 		{name: "CMPXCHGLlock", argLength: 4, reg: cmpxchg, asm: "CMPXCHGL", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr"},
 		{name: "CMPXCHGQlock", argLength: 4, reg: cmpxchg, asm: "CMPXCHGQ", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr"},
 
+		// Atomic compare-and-exchange returning old value (for atomix CAX operations).
+		{name: "CMPXCHGLlockValue", argLength: 4, reg: cmpxchgValue, asm: "CMPXCHGL", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr"}, // Returns old value in AX
+		{name: "CMPXCHGQlockValue", argLength: 4, reg: cmpxchgValue, asm: "CMPXCHGQ", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr"}, // Returns old value in AX
+
 		// Atomic memory updates using logical operations.
 		// Old style that just returns the memory state.
 		{name: "ANDBlock", argLength: 3, reg: gpstore, asm: "ANDB", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr"}, // *(arg0+auxint+aux) &= arg1
@@ -1197,6 +1205,8 @@ func init() {
 		{name: "ORBlock", argLength: 3, reg: gpstore, asm: "ORB", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr"},   // *(arg0+auxint+aux) |= arg1
 		{name: "ORLlock", argLength: 3, reg: gpstore, asm: "ORL", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr"},   // *(arg0+auxint+aux) |= arg1
 		{name: "ORQlock", argLength: 3, reg: gpstore, asm: "ORQ", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr"},   // *(arg0+auxint+aux) |= arg1
+		{name: "XORLlock", argLength: 3, reg: gpstore, asm: "XORL", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr"}, // *(arg0+auxint+aux) ^= arg1
+		{name: "XORQlock", argLength: 3, reg: gpstore, asm: "XORQ", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr"}, // *(arg0+auxint+aux) ^= arg1
 
 		// Atomic memory updates using logical operations.
 		// *(arg0+auxint+aux) op= arg1. arg2=mem.
@@ -1205,6 +1215,8 @@ func init() {
 		{name: "LoweredAtomicAnd32", argLength: 3, reg: atomicLogic, resultNotInArgs: true, asm: "ANDL", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr", unsafePoint: true, needIntTemp: true},
 		{name: "LoweredAtomicOr64", argLength: 3, reg: atomicLogic, resultNotInArgs: true, asm: "ORQ", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr", unsafePoint: true, needIntTemp: true},
 		{name: "LoweredAtomicOr32", argLength: 3, reg: atomicLogic, resultNotInArgs: true, asm: "ORL", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr", unsafePoint: true, needIntTemp: true},
+		{name: "LoweredAtomicXor64", argLength: 3, reg: atomicLogic, resultNotInArgs: true, asm: "XORQ", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr", unsafePoint: true, needIntTemp: true},
+		{name: "LoweredAtomicXor32", argLength: 3, reg: atomicLogic, resultNotInArgs: true, asm: "XORL", aux: "SymOff", clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, symEffect: "RdWr", unsafePoint: true, needIntTemp: true},
 
 		// Prefetch instructions
 		// Do prefetch arg0 address. arg0=addr, arg1=memory. Instruction variant selects locality hint

--- a/src/cmd/compile/internal/ssa/_gen/ARM64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/ARM64.rules
@@ -518,22 +518,50 @@
 (AtomicExchange(8|32|64)       ...) => (LoweredAtomicExchange(8|32|64) ...)
 (AtomicAdd(32|64)            ...) => (LoweredAtomicAdd(32|64)      ...)
 (AtomicCompareAndSwap(32|64) ...) => (LoweredAtomicCas(32|64)      ...)
+(AtomicCompareAndExchange(32|64) ...) => (LoweredAtomicCax(32|64)      ...)
 
 (AtomicAdd(32|64)Variant            ...) => (LoweredAtomicAdd(32|64)Variant      ...)
 (AtomicExchange(8|32|64)Variant       ...) => (LoweredAtomicExchange(8|32|64)Variant ...)
 (AtomicCompareAndSwap(32|64)Variant ...) => (LoweredAtomicCas(32|64)Variant      ...)
+(AtomicCompareAndExchange(32|64)Variant ...) => (LoweredAtomicCax(32|64)Variant      ...)
 
 // Return old contents.
 (AtomicAnd(64|32|8)value            ...) => (LoweredAtomicAnd(64|32|8)            ...)
 (AtomicOr(64|32|8)value             ...) => (LoweredAtomicOr(64|32|8)             ...)
+(AtomicXor(64|32)value              ...) => (LoweredAtomicXor(64|32)              ...)
 (AtomicAnd(64|32|8)valueVariant     ...) => (LoweredAtomicAnd(64|32|8)Variant     ...)
 (AtomicOr(64|32|8)valueVariant      ...) => (LoweredAtomicOr(64|32|8)Variant      ...)
+(AtomicXor(64|32)valueVariant       ...) => (LoweredAtomicXor(64|32)Variant       ...)
+
+// Relaxed atomic operations (no acquire/release semantics).
+// Use plain MOV instead of LDAR/STLR.
+(AtomicLoad8Relaxed   ptr mem) => (LoweredAtomicLoad8Relaxed  ptr mem)
+(AtomicLoad32Relaxed  ptr mem) => (LoweredAtomicLoad32Relaxed ptr mem)
+(AtomicLoad64Relaxed  ptr mem) => (LoweredAtomicLoad64Relaxed ptr mem)
+(AtomicLoadPtrRelaxed ptr mem) => (LoweredAtomicLoad64Relaxed ptr mem)
+(AtomicStore8Relaxed          ptr val mem) => (LoweredAtomicStore8Relaxed  ptr val mem)
+(AtomicStore32Relaxed         ptr val mem) => (LoweredAtomicStore32Relaxed ptr val mem)
+(AtomicStore64Relaxed         ptr val mem) => (LoweredAtomicStore64Relaxed ptr val mem)
+(AtomicStorePtrRelaxedNoWB    ptr val mem) => (LoweredAtomicStore64Relaxed ptr val mem)
 
 // Write barrier.
 (WB ...) => (LoweredWB ...)
 
 // Publication barrier (0xe is ST option)
 (PubBarrier mem) => (DMB [0xe] mem)
+
+// DMB fence coalescing.
+// DMB options: 0x9=ISHLD (acquire), 0xA=ISHST (release), 0xB=ISH (full), 0xE=ST (store-only)
+// Duplicate barriers are eliminated.
+(DMB [a] (DMB [a] mem)) => (DMB [a] mem)
+// Full barrier subsumes weaker barriers.
+(DMB [0xB] (DMB [0x9] mem)) => (DMB [0xB] mem)
+(DMB [0xB] (DMB [0xA] mem)) => (DMB [0xB] mem)
+(DMB [0x9] (DMB [0xB] mem)) => (DMB [0xB] mem)
+(DMB [0xA] (DMB [0xB] mem)) => (DMB [0xB] mem)
+// Acquire + release → full barrier.
+(DMB [0x9] (DMB [0xA] mem)) => (DMB [0xB] mem)
+(DMB [0xA] (DMB [0x9] mem)) => (DMB [0xB] mem)
 
 (PanicBounds ...) => (LoweredPanicBoundsRR ...)
 (LoweredPanicBoundsRR [kind] x (MOVDconst [c]) mem) => (LoweredPanicBoundsRC [kind] x {PanicBoundsC{C:c}} mem)

--- a/src/cmd/compile/internal/ssa/_gen/ARM64Ops.go
+++ b/src/cmd/compile/internal/ssa/_gen/ARM64Ops.go
@@ -730,6 +730,20 @@ func init() {
 		{name: "LoweredAtomicCas64Variant", argLength: 4, reg: gpcas, resultNotInArgs: true, clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true},
 		{name: "LoweredAtomicCas32Variant", argLength: 4, reg: gpcas, resultNotInArgs: true, clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true},
 
+		// atomic compare and exchange (returns old value).
+		// LDAXR	(Rarg0), Rout
+		// CMP		Rarg1, Rout
+		// BNE		3(PC)
+		// STLXR	Rarg2, (Rarg0), Rtmp
+		// CBNZ		Rtmp, -4(PC)
+		{name: "LoweredAtomicCax64", argLength: 4, reg: gpcas, resultNotInArgs: true, clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true},
+		{name: "LoweredAtomicCax32", argLength: 4, reg: gpcas, resultNotInArgs: true, clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true},
+
+		// atomic compare and exchange variant (using LSE CASAL).
+		// CASALW Rarg1, Rarg2, (Rarg0) - Rarg1 holds old value after operation
+		{name: "LoweredAtomicCax64Variant", argLength: 4, reg: gpcas, resultNotInArgs: true, clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true},
+		{name: "LoweredAtomicCax32Variant", argLength: 4, reg: gpcas, resultNotInArgs: true, clobberFlags: true, faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true},
+
 		// atomic and/or.
 		// *arg0 &= (|=) arg1. arg2=mem. returns <old content of *arg0, memory>. auxint must be zero.
 		// LDAXR	(Rarg0), Rout
@@ -742,6 +756,9 @@ func init() {
 		{name: "LoweredAtomicOr64", argLength: 3, reg: gpxchg, resultNotInArgs: true, asm: "ORR", faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true, needIntTemp: true},
 		{name: "LoweredAtomicAnd32", argLength: 3, reg: gpxchg, resultNotInArgs: true, asm: "AND", faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true, needIntTemp: true},
 		{name: "LoweredAtomicOr32", argLength: 3, reg: gpxchg, resultNotInArgs: true, asm: "ORR", faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true, needIntTemp: true},
+		{name: "LoweredAtomicXor8", argLength: 3, reg: gpxchg, resultNotInArgs: true, asm: "EOR", faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true, needIntTemp: true},
+		{name: "LoweredAtomicXor64", argLength: 3, reg: gpxchg, resultNotInArgs: true, asm: "EOR", faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true, needIntTemp: true},
+		{name: "LoweredAtomicXor32", argLength: 3, reg: gpxchg, resultNotInArgs: true, asm: "EOR", faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true, needIntTemp: true},
 
 		// atomic and/or variant.
 		// *arg0 &= (|=) arg1. arg2=mem. returns <old content of *arg0, memory>. auxint must be zero.
@@ -756,6 +773,21 @@ func init() {
 		{name: "LoweredAtomicOr64Variant", argLength: 3, reg: gpxchg, resultNotInArgs: true, faultOnNilArg0: true, hasSideEffects: true},
 		{name: "LoweredAtomicAnd32Variant", argLength: 3, reg: gpxchg, resultNotInArgs: true, faultOnNilArg0: true, hasSideEffects: true, unsafePoint: true},
 		{name: "LoweredAtomicOr32Variant", argLength: 3, reg: gpxchg, resultNotInArgs: true, faultOnNilArg0: true, hasSideEffects: true},
+		{name: "LoweredAtomicXor8Variant", argLength: 3, reg: gpxchg, resultNotInArgs: true, faultOnNilArg0: true, hasSideEffects: true},
+		{name: "LoweredAtomicXor64Variant", argLength: 3, reg: gpxchg, resultNotInArgs: true, faultOnNilArg0: true, hasSideEffects: true},
+		{name: "LoweredAtomicXor32Variant", argLength: 3, reg: gpxchg, resultNotInArgs: true, faultOnNilArg0: true, hasSideEffects: true},
+
+		// Relaxed atomic loads (no acquire semantics).
+		// Uses plain MOV instead of LDAR for better performance when ordering is not needed.
+		{name: "LoweredAtomicLoad8Relaxed", argLength: 2, reg: gpload, asm: "MOVBU", faultOnNilArg0: true},
+		{name: "LoweredAtomicLoad32Relaxed", argLength: 2, reg: gpload, asm: "MOVWU", faultOnNilArg0: true},
+		{name: "LoweredAtomicLoad64Relaxed", argLength: 2, reg: gpload, asm: "MOVD", faultOnNilArg0: true},
+
+		// Relaxed atomic stores (no release semantics).
+		// Uses plain MOV instead of STLR for better performance when ordering is not needed.
+		{name: "LoweredAtomicStore8Relaxed", argLength: 3, reg: gpstore, asm: "MOVB", typ: "Mem", faultOnNilArg0: true, hasSideEffects: true},
+		{name: "LoweredAtomicStore32Relaxed", argLength: 3, reg: gpstore, asm: "MOVW", typ: "Mem", faultOnNilArg0: true, hasSideEffects: true},
+		{name: "LoweredAtomicStore64Relaxed", argLength: 3, reg: gpstore, asm: "MOVD", typ: "Mem", faultOnNilArg0: true, hasSideEffects: true},
 
 		// LoweredWB invokes runtime.gcWriteBarrier. arg0=mem, auxint=# of buffer entries needed
 		// It saves all GP registers if necessary,

--- a/src/cmd/compile/internal/ssa/_gen/generic.rules
+++ b/src/cmd/compile/internal/ssa/_gen/generic.rules
@@ -2280,3 +2280,32 @@
 (Neq(64|32|16) (SignExt8to(64|32|16) (CvtBoolToUint8 x)) (Const(64|32|16) [1])) => (Not x)
 (Eq(64|32|16)  (SignExt8to(64|32|16) (CvtBoolToUint8 x)) (Const(64|32|16) [1])) => x
 (Eq(64|32|16)  (SignExt8to(64|32|16) (CvtBoolToUint8 x)) (Const(64|32|16) [0])) => (Not x)
+
+// Atomic operation constant folding
+// AtomicAdd with 0 is just a load (Add returns new value = old + 0 = old)
+(AtomicAdd32 ptr (Const32 [0]) mem) => (AtomicLoad32 ptr mem)
+(AtomicAdd64 ptr (Const64 [0]) mem) => (AtomicLoad64 ptr mem)
+(AtomicAdd32Variant ptr (Const32 [0]) mem) => (AtomicLoad32 ptr mem)
+(AtomicAdd64Variant ptr (Const64 [0]) mem) => (AtomicLoad64 ptr mem)
+
+// AtomicOr with 0 is just a load (returns old value, value unchanged)
+(AtomicOr64value ptr (Const64 [0]) mem) => (AtomicLoad64 ptr mem)
+(AtomicOr32value ptr (Const32 [0]) mem) => (AtomicLoad32 ptr mem)
+(AtomicOr8value ptr (Const8 [0]) mem) => (AtomicLoad8 ptr mem)
+(AtomicOr64valueVariant ptr (Const64 [0]) mem) => (AtomicLoad64 ptr mem)
+(AtomicOr32valueVariant ptr (Const32 [0]) mem) => (AtomicLoad32 ptr mem)
+(AtomicOr8valueVariant ptr (Const8 [0]) mem) => (AtomicLoad8 ptr mem)
+
+// AtomicAnd with all-ones is just a load (returns old value, value unchanged)
+(AtomicAnd64value ptr (Const64 [-1]) mem) => (AtomicLoad64 ptr mem)
+(AtomicAnd32value ptr (Const32 [-1]) mem) => (AtomicLoad32 ptr mem)
+(AtomicAnd8value ptr (Const8 [-1]) mem) => (AtomicLoad8 ptr mem)
+(AtomicAnd64valueVariant ptr (Const64 [-1]) mem) => (AtomicLoad64 ptr mem)
+(AtomicAnd32valueVariant ptr (Const32 [-1]) mem) => (AtomicLoad32 ptr mem)
+(AtomicAnd8valueVariant ptr (Const8 [-1]) mem) => (AtomicLoad8 ptr mem)
+
+// AtomicXor with 0 is just a load (returns old value, value unchanged)
+(AtomicXor64value ptr (Const64 [0]) mem) => (AtomicLoad64 ptr mem)
+(AtomicXor32value ptr (Const32 [0]) mem) => (AtomicLoad32 ptr mem)
+(AtomicXor64valueVariant ptr (Const64 [0]) mem) => (AtomicLoad64 ptr mem)
+(AtomicXor32valueVariant ptr (Const32 [0]) mem) => (AtomicLoad32 ptr mem)

--- a/src/cmd/compile/internal/ssa/_gen/genericOps.go
+++ b/src/cmd/compile/internal/ssa/_gen/genericOps.go
@@ -631,6 +631,10 @@ var genericOps = []opData{
 	{name: "AtomicCompareAndSwap64", argLength: 4, typ: "(Bool,Mem)", hasSideEffects: true},    // if *arg0==arg1, then set *arg0=arg2.  Returns true if store happens and new memory.
 	{name: "AtomicCompareAndSwapRel32", argLength: 4, typ: "(Bool,Mem)", hasSideEffects: true}, // if *arg0==arg1, then set *arg0=arg2.  Lock release, reports whether store happens and new memory.
 
+	// Atomic compare-and-exchange returning old value (for atomix CAX operations).
+	{name: "AtomicCompareAndExchange32", argLength: 4, typ: "(UInt32,Mem)", hasSideEffects: true}, // if *arg0==arg1, then set *arg0=arg2.  Returns old value of *arg0 and new memory.
+	{name: "AtomicCompareAndExchange64", argLength: 4, typ: "(UInt64,Mem)", hasSideEffects: true}, // if *arg0==arg1, then set *arg0=arg2.  Returns old value of *arg0 and new memory.
+
 	// Older atomic logical operations which don't return the old value.
 	{name: "AtomicAnd8", argLength: 3, typ: "Mem", hasSideEffects: true},  // *arg0 &= arg1.  arg2=memory.  Returns memory.
 	{name: "AtomicOr8", argLength: 3, typ: "Mem", hasSideEffects: true},   // *arg0 |= arg1.  arg2=memory.  Returns memory.
@@ -644,6 +648,8 @@ var genericOps = []opData{
 	{name: "AtomicOr64value", argLength: 3, typ: "(Uint64, Mem)", hasSideEffects: true},  // *arg0 |= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
 	{name: "AtomicOr32value", argLength: 3, typ: "(Uint32, Mem)", hasSideEffects: true},  // *arg0 |= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
 	{name: "AtomicOr8value", argLength: 3, typ: "(Uint8, Mem)", hasSideEffects: true},    // *arg0 |= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
+	{name: "AtomicXor64value", argLength: 3, typ: "(Uint64, Mem)", hasSideEffects: true}, // *arg0 ^= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
+	{name: "AtomicXor32value", argLength: 3, typ: "(Uint32, Mem)", hasSideEffects: true}, // *arg0 ^= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
 
 	// Atomic operation variants
 	// These variants have the same semantics as above atomic operations.
@@ -659,14 +665,29 @@ var genericOps = []opData{
 	{name: "AtomicExchange8Variant", argLength: 3, typ: "(UInt8,Mem)", hasSideEffects: true},       // Store arg1 to *arg0.  arg2=memory.  Returns old contents of *arg0 and new memory.
 	{name: "AtomicExchange32Variant", argLength: 3, typ: "(UInt32,Mem)", hasSideEffects: true},     // Store arg1 to *arg0.  arg2=memory.  Returns old contents of *arg0 and new memory.
 	{name: "AtomicExchange64Variant", argLength: 3, typ: "(UInt64,Mem)", hasSideEffects: true},     // Store arg1 to *arg0.  arg2=memory.  Returns old contents of *arg0 and new memory.
-	{name: "AtomicCompareAndSwap32Variant", argLength: 4, typ: "(Bool,Mem)", hasSideEffects: true}, // if *arg0==arg1, then set *arg0=arg2.  Returns true if store happens and new memory.
-	{name: "AtomicCompareAndSwap64Variant", argLength: 4, typ: "(Bool,Mem)", hasSideEffects: true}, // if *arg0==arg1, then set *arg0=arg2.  Returns true if store happens and new memory.
+	{name: "AtomicCompareAndSwap32Variant", argLength: 4, typ: "(Bool,Mem)", hasSideEffects: true},     // if *arg0==arg1, then set *arg0=arg2.  Returns true if store happens and new memory.
+	{name: "AtomicCompareAndSwap64Variant", argLength: 4, typ: "(Bool,Mem)", hasSideEffects: true},     // if *arg0==arg1, then set *arg0=arg2.  Returns true if store happens and new memory.
+	{name: "AtomicCompareAndExchange32Variant", argLength: 4, typ: "(UInt32,Mem)", hasSideEffects: true}, // if *arg0==arg1, then set *arg0=arg2.  Returns old value of *arg0 and new memory.
+	{name: "AtomicCompareAndExchange64Variant", argLength: 4, typ: "(UInt64,Mem)", hasSideEffects: true}, // if *arg0==arg1, then set *arg0=arg2.  Returns old value of *arg0 and new memory.
 	{name: "AtomicAnd64valueVariant", argLength: 3, typ: "(Uint64, Mem)", hasSideEffects: true},    // *arg0 &= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
 	{name: "AtomicOr64valueVariant", argLength: 3, typ: "(Uint64, Mem)", hasSideEffects: true},     // *arg0 |= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
 	{name: "AtomicAnd32valueVariant", argLength: 3, typ: "(Uint32, Mem)", hasSideEffects: true},    // *arg0 &= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
 	{name: "AtomicOr32valueVariant", argLength: 3, typ: "(Uint32, Mem)", hasSideEffects: true},     // *arg0 |= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
 	{name: "AtomicAnd8valueVariant", argLength: 3, typ: "(Uint8, Mem)", hasSideEffects: true},      // *arg0 &= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
 	{name: "AtomicOr8valueVariant", argLength: 3, typ: "(Uint8, Mem)", hasSideEffects: true},       // *arg0 |= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
+	{name: "AtomicXor64valueVariant", argLength: 3, typ: "(Uint64, Mem)", hasSideEffects: true},    // *arg0 ^= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
+	{name: "AtomicXor32valueVariant", argLength: 3, typ: "(Uint32, Mem)", hasSideEffects: true},    // *arg0 ^= arg1.  arg2=memory.  Returns old contents of *arg0 and new memory.
+
+	// Relaxed atomic operations (no memory ordering guarantees)
+	// These ops have no acquire/release semantics - use plain loads/stores on architectures that support them.
+	{name: "AtomicLoad8Relaxed", argLength: 2, typ: "(UInt8,Mem)"},                        // Relaxed load from arg0.  arg1=memory.  Returns loaded value and new memory.
+	{name: "AtomicLoad32Relaxed", argLength: 2, typ: "(UInt32,Mem)"},                      // Relaxed load from arg0.  arg1=memory.  Returns loaded value and new memory.
+	{name: "AtomicLoad64Relaxed", argLength: 2, typ: "(UInt64,Mem)"},                      // Relaxed load from arg0.  arg1=memory.  Returns loaded value and new memory.
+	{name: "AtomicLoadPtrRelaxed", argLength: 2, typ: "(BytePtr,Mem)"},                    // Relaxed load from arg0.  arg1=memory.  Returns loaded value and new memory.
+	{name: "AtomicStore8Relaxed", argLength: 3, typ: "Mem", hasSideEffects: true},         // Relaxed store arg1 to *arg0.  arg2=memory.  Returns memory.
+	{name: "AtomicStore32Relaxed", argLength: 3, typ: "Mem", hasSideEffects: true},        // Relaxed store arg1 to *arg0.  arg2=memory.  Returns memory.
+	{name: "AtomicStore64Relaxed", argLength: 3, typ: "Mem", hasSideEffects: true},        // Relaxed store arg1 to *arg0.  arg2=memory.  Returns memory.
+	{name: "AtomicStorePtrRelaxedNoWB", argLength: 3, typ: "Mem", hasSideEffects: true},   // Relaxed store arg1 to *arg0.  arg2=memory.  Returns memory.
 
 	// Publication barrier
 	{name: "PubBarrier", argLength: 1, hasSideEffects: true}, // Do data barrier. arg0=memory.

--- a/src/cmd/compile/internal/ssa/opGen.go
+++ b/src/cmd/compile/internal/ssa/opGen.go
@@ -1072,6 +1072,7 @@ const (
 	OpAMD64LoweredNilCheck
 	OpAMD64LoweredWB
 	OpAMD64LoweredHasCPUFeature
+	OpAMD64MFENCE
 	OpAMD64LoweredPanicBoundsRR
 	OpAMD64LoweredPanicBoundsRC
 	OpAMD64LoweredPanicBoundsCR
@@ -1093,16 +1094,22 @@ const (
 	OpAMD64AddTupleFirst64
 	OpAMD64CMPXCHGLlock
 	OpAMD64CMPXCHGQlock
+	OpAMD64CMPXCHGLlockValue
+	OpAMD64CMPXCHGQlockValue
 	OpAMD64ANDBlock
 	OpAMD64ANDLlock
 	OpAMD64ANDQlock
 	OpAMD64ORBlock
 	OpAMD64ORLlock
 	OpAMD64ORQlock
+	OpAMD64XORLlock
+	OpAMD64XORQlock
 	OpAMD64LoweredAtomicAnd64
 	OpAMD64LoweredAtomicAnd32
 	OpAMD64LoweredAtomicOr64
 	OpAMD64LoweredAtomicOr32
+	OpAMD64LoweredAtomicXor64
+	OpAMD64LoweredAtomicXor32
 	OpAMD64PrefetchT0
 	OpAMD64PrefetchNTA
 	OpAMD64ANDNQ
@@ -4472,18 +4479,34 @@ const (
 	OpARM64LoweredAtomicCas32
 	OpARM64LoweredAtomicCas64Variant
 	OpARM64LoweredAtomicCas32Variant
+	OpARM64LoweredAtomicCax64
+	OpARM64LoweredAtomicCax32
+	OpARM64LoweredAtomicCax64Variant
+	OpARM64LoweredAtomicCax32Variant
 	OpARM64LoweredAtomicAnd8
 	OpARM64LoweredAtomicOr8
 	OpARM64LoweredAtomicAnd64
 	OpARM64LoweredAtomicOr64
 	OpARM64LoweredAtomicAnd32
 	OpARM64LoweredAtomicOr32
+	OpARM64LoweredAtomicXor8
+	OpARM64LoweredAtomicXor64
+	OpARM64LoweredAtomicXor32
 	OpARM64LoweredAtomicAnd8Variant
 	OpARM64LoweredAtomicOr8Variant
 	OpARM64LoweredAtomicAnd64Variant
 	OpARM64LoweredAtomicOr64Variant
 	OpARM64LoweredAtomicAnd32Variant
 	OpARM64LoweredAtomicOr32Variant
+	OpARM64LoweredAtomicXor8Variant
+	OpARM64LoweredAtomicXor64Variant
+	OpARM64LoweredAtomicXor32Variant
+	OpARM64LoweredAtomicLoad8Relaxed
+	OpARM64LoweredAtomicLoad32Relaxed
+	OpARM64LoweredAtomicLoad64Relaxed
+	OpARM64LoweredAtomicStore8Relaxed
+	OpARM64LoweredAtomicStore32Relaxed
+	OpARM64LoweredAtomicStore64Relaxed
 	OpARM64LoweredWB
 	OpARM64LoweredPanicBoundsRR
 	OpARM64LoweredPanicBoundsRC
@@ -6106,6 +6129,8 @@ const (
 	OpAtomicCompareAndSwap32
 	OpAtomicCompareAndSwap64
 	OpAtomicCompareAndSwapRel32
+	OpAtomicCompareAndExchange32
+	OpAtomicCompareAndExchange64
 	OpAtomicAnd8
 	OpAtomicOr8
 	OpAtomicAnd32
@@ -6116,6 +6141,8 @@ const (
 	OpAtomicOr64value
 	OpAtomicOr32value
 	OpAtomicOr8value
+	OpAtomicXor64value
+	OpAtomicXor32value
 	OpAtomicStore8Variant
 	OpAtomicStore32Variant
 	OpAtomicStore64Variant
@@ -6126,12 +6153,24 @@ const (
 	OpAtomicExchange64Variant
 	OpAtomicCompareAndSwap32Variant
 	OpAtomicCompareAndSwap64Variant
+	OpAtomicCompareAndExchange32Variant
+	OpAtomicCompareAndExchange64Variant
 	OpAtomicAnd64valueVariant
 	OpAtomicOr64valueVariant
 	OpAtomicAnd32valueVariant
 	OpAtomicOr32valueVariant
 	OpAtomicAnd8valueVariant
 	OpAtomicOr8valueVariant
+	OpAtomicXor64valueVariant
+	OpAtomicXor32valueVariant
+	OpAtomicLoad8Relaxed
+	OpAtomicLoad32Relaxed
+	OpAtomicLoad64Relaxed
+	OpAtomicLoadPtrRelaxed
+	OpAtomicStore8Relaxed
+	OpAtomicStore32Relaxed
+	OpAtomicStore64Relaxed
+	OpAtomicStorePtrRelaxedNoWB
 	OpPubBarrier
 	OpClobber
 	OpClobberReg
@@ -18215,6 +18254,13 @@ var opcodeTable = [...]opInfo{
 		},
 	},
 	{
+		name:           "MFENCE",
+		argLen:         1,
+		hasSideEffects: true,
+		asm:            x86.AMFENCE,
+		reg:            regInfo{},
+	},
+	{
 		name:    "LoweredPanicBoundsRR",
 		auxType: auxInt64,
 		argLen:  3,
@@ -18480,6 +18526,48 @@ var opcodeTable = [...]opInfo{
 		},
 	},
 	{
+		name:           "CMPXCHGLlockValue",
+		auxType:        auxSymOff,
+		argLen:         4,
+		clobberFlags:   true,
+		faultOnNilArg0: true,
+		hasSideEffects: true,
+		symEffect:      SymRdWr,
+		asm:            x86.ACMPXCHGL,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 1},     // AX
+				{0, 49135}, // AX CX DX BX BP SI DI R8 R9 R10 R11 R12 R13 R15
+				{2, 49135}, // AX CX DX BX BP SI DI R8 R9 R10 R11 R12 R13 R15
+			},
+			outputs: []outputInfo{
+				{1, 0},
+				{0, 1}, // AX
+			},
+		},
+	},
+	{
+		name:           "CMPXCHGQlockValue",
+		auxType:        auxSymOff,
+		argLen:         4,
+		clobberFlags:   true,
+		faultOnNilArg0: true,
+		hasSideEffects: true,
+		symEffect:      SymRdWr,
+		asm:            x86.ACMPXCHGQ,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 1},     // AX
+				{0, 49135}, // AX CX DX BX BP SI DI R8 R9 R10 R11 R12 R13 R15
+				{2, 49135}, // AX CX DX BX BP SI DI R8 R9 R10 R11 R12 R13 R15
+			},
+			outputs: []outputInfo{
+				{1, 0},
+				{0, 1}, // AX
+			},
+		},
+	},
+	{
 		name:           "ANDBlock",
 		auxType:        auxSymOff,
 		argLen:         3,
@@ -18576,6 +18664,38 @@ var opcodeTable = [...]opInfo{
 		},
 	},
 	{
+		name:           "XORLlock",
+		auxType:        auxSymOff,
+		argLen:         3,
+		clobberFlags:   true,
+		faultOnNilArg0: true,
+		hasSideEffects: true,
+		symEffect:      SymRdWr,
+		asm:            x86.AXORL,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 49151},             // AX CX DX BX SP BP SI DI R8 R9 R10 R11 R12 R13 R15
+				{0, 72057594037993471}, // AX CX DX BX SP BP SI DI R8 R9 R10 R11 R12 R13 g R15 SB
+			},
+		},
+	},
+	{
+		name:           "XORQlock",
+		auxType:        auxSymOff,
+		argLen:         3,
+		clobberFlags:   true,
+		faultOnNilArg0: true,
+		hasSideEffects: true,
+		symEffect:      SymRdWr,
+		asm:            x86.AXORQ,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 49151},             // AX CX DX BX SP BP SI DI R8 R9 R10 R11 R12 R13 R15
+				{0, 72057594037993471}, // AX CX DX BX SP BP SI DI R8 R9 R10 R11 R12 R13 g R15 SB
+			},
+		},
+	},
+	{
 		name:            "LoweredAtomicAnd64",
 		auxType:         auxSymOff,
 		argLen:          3,
@@ -18656,6 +18776,52 @@ var opcodeTable = [...]opInfo{
 		unsafePoint:     true,
 		symEffect:       SymRdWr,
 		asm:             x86.AORL,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{0, 49134}, // CX DX BX BP SI DI R8 R9 R10 R11 R12 R13 R15
+				{1, 49134}, // CX DX BX BP SI DI R8 R9 R10 R11 R12 R13 R15
+			},
+			outputs: []outputInfo{
+				{1, 0},
+				{0, 1}, // AX
+			},
+		},
+	},
+	{
+		name:            "LoweredAtomicXor64",
+		auxType:         auxSymOff,
+		argLen:          3,
+		resultNotInArgs: true,
+		clobberFlags:    true,
+		needIntTemp:     true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		unsafePoint:     true,
+		symEffect:       SymRdWr,
+		asm:             x86.AXORQ,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{0, 49134}, // CX DX BX BP SI DI R8 R9 R10 R11 R12 R13 R15
+				{1, 49134}, // CX DX BX BP SI DI R8 R9 R10 R11 R12 R13 R15
+			},
+			outputs: []outputInfo{
+				{1, 0},
+				{0, 1}, // AX
+			},
+		},
+	},
+	{
+		name:            "LoweredAtomicXor32",
+		auxType:         auxSymOff,
+		argLen:          3,
+		resultNotInArgs: true,
+		clobberFlags:    true,
+		needIntTemp:     true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		unsafePoint:     true,
+		symEffect:       SymRdWr,
+		asm:             x86.AXORL,
 		reg: regInfo{
 			inputs: []inputInfo{
 				{0, 49134}, // CX DX BX BP SI DI R8 R9 R10 R11 R12 R13 R15
@@ -69543,6 +69709,82 @@ var opcodeTable = [...]opInfo{
 		},
 	},
 	{
+		name:            "LoweredAtomicCax64",
+		argLen:          4,
+		resultNotInArgs: true,
+		clobberFlags:    true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		unsafePoint:     true,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{2, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:            "LoweredAtomicCax32",
+		argLen:          4,
+		resultNotInArgs: true,
+		clobberFlags:    true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		unsafePoint:     true,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{2, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:            "LoweredAtomicCax64Variant",
+		argLen:          4,
+		resultNotInArgs: true,
+		clobberFlags:    true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		unsafePoint:     true,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{2, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:            "LoweredAtomicCax32Variant",
+		argLen:          4,
+		resultNotInArgs: true,
+		clobberFlags:    true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		unsafePoint:     true,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{2, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
 		name:            "LoweredAtomicAnd8",
 		argLen:          3,
 		resultNotInArgs: true,
@@ -69657,6 +69899,63 @@ var opcodeTable = [...]opInfo{
 		},
 	},
 	{
+		name:            "LoweredAtomicXor8",
+		argLen:          3,
+		resultNotInArgs: true,
+		needIntTemp:     true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		unsafePoint:     true,
+		asm:             arm64.AEOR,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:            "LoweredAtomicXor64",
+		argLen:          3,
+		resultNotInArgs: true,
+		needIntTemp:     true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		unsafePoint:     true,
+		asm:             arm64.AEOR,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:            "LoweredAtomicXor32",
+		argLen:          3,
+		resultNotInArgs: true,
+		needIntTemp:     true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		unsafePoint:     true,
+		asm:             arm64.AEOR,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
 		name:            "LoweredAtomicAnd8Variant",
 		argLen:          3,
 		resultNotInArgs: true,
@@ -69752,6 +70051,135 @@ var opcodeTable = [...]opInfo{
 			},
 			outputs: []outputInfo{
 				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:            "LoweredAtomicXor8Variant",
+		argLen:          3,
+		resultNotInArgs: true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:            "LoweredAtomicXor64Variant",
+		argLen:          3,
+		resultNotInArgs: true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:            "LoweredAtomicXor32Variant",
+		argLen:          3,
+		resultNotInArgs: true,
+		faultOnNilArg0:  true,
+		hasSideEffects:  true,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:           "LoweredAtomicLoad8Relaxed",
+		argLen:         2,
+		faultOnNilArg0: true,
+		asm:            arm64.AMOVBU,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:           "LoweredAtomicLoad32Relaxed",
+		argLen:         2,
+		faultOnNilArg0: true,
+		asm:            arm64.AMOVWU,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:           "LoweredAtomicLoad64Relaxed",
+		argLen:         2,
+		faultOnNilArg0: true,
+		asm:            arm64.AMOVD,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+			outputs: []outputInfo{
+				{0, 335544319}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 R30
+			},
+		},
+	},
+	{
+		name:           "LoweredAtomicStore8Relaxed",
+		argLen:         3,
+		faultOnNilArg0: true,
+		hasSideEffects: true,
+		asm:            arm64.AMOVB,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+		},
+	},
+	{
+		name:           "LoweredAtomicStore32Relaxed",
+		argLen:         3,
+		faultOnNilArg0: true,
+		hasSideEffects: true,
+		asm:            arm64.AMOVW,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
+			},
+		},
+	},
+	{
+		name:           "LoweredAtomicStore64Relaxed",
+		argLen:         3,
+		faultOnNilArg0: true,
+		hasSideEffects: true,
+		asm:            arm64.AMOVD,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{1, 939524095},           // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 ZERO
+				{0, 9223372038331170815}, // R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 R16 R17 R19 R20 R21 R22 R23 R24 R25 R26 g R30 SP SB
 			},
 		},
 	},
@@ -88756,6 +89184,18 @@ var opcodeTable = [...]opInfo{
 		generic:        true,
 	},
 	{
+		name:           "AtomicCompareAndExchange32",
+		argLen:         4,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
+		name:           "AtomicCompareAndExchange64",
+		argLen:         4,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
 		name:           "AtomicAnd8",
 		argLen:         3,
 		hasSideEffects: true,
@@ -88811,6 +89251,18 @@ var opcodeTable = [...]opInfo{
 	},
 	{
 		name:           "AtomicOr8value",
+		argLen:         3,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
+		name:           "AtomicXor64value",
+		argLen:         3,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
+		name:           "AtomicXor32value",
 		argLen:         3,
 		hasSideEffects: true,
 		generic:        true,
@@ -88876,6 +89328,18 @@ var opcodeTable = [...]opInfo{
 		generic:        true,
 	},
 	{
+		name:           "AtomicCompareAndExchange32Variant",
+		argLen:         4,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
+		name:           "AtomicCompareAndExchange64Variant",
+		argLen:         4,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
 		name:           "AtomicAnd64valueVariant",
 		argLen:         3,
 		hasSideEffects: true,
@@ -88907,6 +89371,62 @@ var opcodeTable = [...]opInfo{
 	},
 	{
 		name:           "AtomicOr8valueVariant",
+		argLen:         3,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
+		name:           "AtomicXor64valueVariant",
+		argLen:         3,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
+		name:           "AtomicXor32valueVariant",
+		argLen:         3,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
+		name:    "AtomicLoad8Relaxed",
+		argLen:  2,
+		generic: true,
+	},
+	{
+		name:    "AtomicLoad32Relaxed",
+		argLen:  2,
+		generic: true,
+	},
+	{
+		name:    "AtomicLoad64Relaxed",
+		argLen:  2,
+		generic: true,
+	},
+	{
+		name:    "AtomicLoadPtrRelaxed",
+		argLen:  2,
+		generic: true,
+	},
+	{
+		name:           "AtomicStore8Relaxed",
+		argLen:         3,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
+		name:           "AtomicStore32Relaxed",
+		argLen:         3,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
+		name:           "AtomicStore64Relaxed",
+		argLen:         3,
+		hasSideEffects: true,
+		generic:        true,
+	},
+	{
+		name:           "AtomicStorePtrRelaxedNoWB",
 		argLen:         3,
 		hasSideEffects: true,
 		generic:        true,

--- a/src/cmd/compile/internal/ssa/rewriteAMD64.go
+++ b/src/cmd/compile/internal/ssa/rewriteAMD64.go
@@ -220,8 +220,12 @@ func rewriteValueAMD64(v *Value) bool {
 		return rewriteValueAMD64_OpAMD64CMPWload(v)
 	case OpAMD64CMPXCHGLlock:
 		return rewriteValueAMD64_OpAMD64CMPXCHGLlock(v)
+	case OpAMD64CMPXCHGLlockValue:
+		return rewriteValueAMD64_OpAMD64CMPXCHGLlockValue(v)
 	case OpAMD64CMPXCHGQlock:
 		return rewriteValueAMD64_OpAMD64CMPXCHGQlock(v)
+	case OpAMD64CMPXCHGQlockValue:
+		return rewriteValueAMD64_OpAMD64CMPXCHGQlockValue(v)
 	case OpAMD64DIVSD:
 		return rewriteValueAMD64_OpAMD64DIVSD(v)
 	case OpAMD64DIVSDload:
@@ -272,6 +276,8 @@ func rewriteValueAMD64(v *Value) bool {
 		return rewriteValueAMD64_OpAMD64LoweredPanicBoundsRC(v)
 	case OpAMD64LoweredPanicBoundsRR:
 		return rewriteValueAMD64_OpAMD64LoweredPanicBoundsRR(v)
+	case OpAMD64MFENCE:
+		return rewriteValueAMD64_OpAMD64MFENCE(v)
 	case OpAMD64MOVBELstore:
 		return rewriteValueAMD64_OpAMD64MOVBELstore(v)
 	case OpAMD64MOVBEQstore:
@@ -2416,6 +2422,10 @@ func rewriteValueAMD64(v *Value) bool {
 		return rewriteValueAMD64_OpAtomicAnd64value(v)
 	case OpAtomicAnd8:
 		return rewriteValueAMD64_OpAtomicAnd8(v)
+	case OpAtomicCompareAndExchange32:
+		return rewriteValueAMD64_OpAtomicCompareAndExchange32(v)
+	case OpAtomicCompareAndExchange64:
+		return rewriteValueAMD64_OpAtomicCompareAndExchange64(v)
 	case OpAtomicCompareAndSwap32:
 		return rewriteValueAMD64_OpAtomicCompareAndSwap32(v)
 	case OpAtomicCompareAndSwap64:
@@ -2428,12 +2438,20 @@ func rewriteValueAMD64(v *Value) bool {
 		return rewriteValueAMD64_OpAtomicExchange8(v)
 	case OpAtomicLoad32:
 		return rewriteValueAMD64_OpAtomicLoad32(v)
+	case OpAtomicLoad32Relaxed:
+		return rewriteValueAMD64_OpAtomicLoad32Relaxed(v)
 	case OpAtomicLoad64:
 		return rewriteValueAMD64_OpAtomicLoad64(v)
+	case OpAtomicLoad64Relaxed:
+		return rewriteValueAMD64_OpAtomicLoad64Relaxed(v)
 	case OpAtomicLoad8:
 		return rewriteValueAMD64_OpAtomicLoad8(v)
+	case OpAtomicLoad8Relaxed:
+		return rewriteValueAMD64_OpAtomicLoad8Relaxed(v)
 	case OpAtomicLoadPtr:
 		return rewriteValueAMD64_OpAtomicLoadPtr(v)
+	case OpAtomicLoadPtrRelaxed:
+		return rewriteValueAMD64_OpAtomicLoadPtrRelaxed(v)
 	case OpAtomicOr32:
 		return rewriteValueAMD64_OpAtomicOr32(v)
 	case OpAtomicOr32value:
@@ -2444,12 +2462,24 @@ func rewriteValueAMD64(v *Value) bool {
 		return rewriteValueAMD64_OpAtomicOr8(v)
 	case OpAtomicStore32:
 		return rewriteValueAMD64_OpAtomicStore32(v)
+	case OpAtomicStore32Relaxed:
+		return rewriteValueAMD64_OpAtomicStore32Relaxed(v)
 	case OpAtomicStore64:
 		return rewriteValueAMD64_OpAtomicStore64(v)
+	case OpAtomicStore64Relaxed:
+		return rewriteValueAMD64_OpAtomicStore64Relaxed(v)
 	case OpAtomicStore8:
 		return rewriteValueAMD64_OpAtomicStore8(v)
+	case OpAtomicStore8Relaxed:
+		return rewriteValueAMD64_OpAtomicStore8Relaxed(v)
 	case OpAtomicStorePtrNoWB:
 		return rewriteValueAMD64_OpAtomicStorePtrNoWB(v)
+	case OpAtomicStorePtrRelaxedNoWB:
+		return rewriteValueAMD64_OpAtomicStorePtrRelaxedNoWB(v)
+	case OpAtomicXor32value:
+		return rewriteValueAMD64_OpAtomicXor32value(v)
+	case OpAtomicXor64value:
+		return rewriteValueAMD64_OpAtomicXor64value(v)
 	case OpAverageUint16x16:
 		v.Op = OpAMD64VPAVGW256
 		return true
@@ -13455,6 +13485,36 @@ func rewriteValueAMD64_OpAMD64CMPXCHGLlock(v *Value) bool {
 	}
 	return false
 }
+func rewriteValueAMD64_OpAMD64CMPXCHGLlockValue(v *Value) bool {
+	v_3 := v.Args[3]
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (CMPXCHGLlockValue [off1] {sym} (ADDQconst [off2] ptr) old new_ mem)
+	// cond: is32Bit(int64(off1)+int64(off2))
+	// result: (CMPXCHGLlockValue [off1+off2] {sym} ptr old new_ mem)
+	for {
+		off1 := auxIntToInt32(v.AuxInt)
+		sym := auxToSym(v.Aux)
+		if v_0.Op != OpAMD64ADDQconst {
+			break
+		}
+		off2 := auxIntToInt32(v_0.AuxInt)
+		ptr := v_0.Args[0]
+		old := v_1
+		new_ := v_2
+		mem := v_3
+		if !(is32Bit(int64(off1) + int64(off2))) {
+			break
+		}
+		v.reset(OpAMD64CMPXCHGLlockValue)
+		v.AuxInt = int32ToAuxInt(off1 + off2)
+		v.Aux = symToAux(sym)
+		v.AddArg4(ptr, old, new_, mem)
+		return true
+	}
+	return false
+}
 func rewriteValueAMD64_OpAMD64CMPXCHGQlock(v *Value) bool {
 	v_3 := v.Args[3]
 	v_2 := v.Args[2]
@@ -13478,6 +13538,36 @@ func rewriteValueAMD64_OpAMD64CMPXCHGQlock(v *Value) bool {
 			break
 		}
 		v.reset(OpAMD64CMPXCHGQlock)
+		v.AuxInt = int32ToAuxInt(off1 + off2)
+		v.Aux = symToAux(sym)
+		v.AddArg4(ptr, old, new_, mem)
+		return true
+	}
+	return false
+}
+func rewriteValueAMD64_OpAMD64CMPXCHGQlockValue(v *Value) bool {
+	v_3 := v.Args[3]
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (CMPXCHGQlockValue [off1] {sym} (ADDQconst [off2] ptr) old new_ mem)
+	// cond: is32Bit(int64(off1)+int64(off2))
+	// result: (CMPXCHGQlockValue [off1+off2] {sym} ptr old new_ mem)
+	for {
+		off1 := auxIntToInt32(v.AuxInt)
+		sym := auxToSym(v.Aux)
+		if v_0.Op != OpAMD64ADDQconst {
+			break
+		}
+		off2 := auxIntToInt32(v_0.AuxInt)
+		ptr := v_0.Args[0]
+		old := v_1
+		new_ := v_2
+		mem := v_3
+		if !(is32Bit(int64(off1) + int64(off2))) {
+			break
+		}
+		v.reset(OpAMD64CMPXCHGQlockValue)
 		v.AuxInt = int32ToAuxInt(off1 + off2)
 		v.Aux = symToAux(sym)
 		v.AddArg4(ptr, old, new_, mem)
@@ -15047,6 +15137,21 @@ func rewriteValueAMD64_OpAMD64LoweredPanicBoundsRR(v *Value) bool {
 		v.AuxInt = int64ToAuxInt(kind)
 		v.Aux = panicBoundsCToAux(PanicBoundsC{C: c})
 		v.AddArg2(y, mem)
+		return true
+	}
+	return false
+}
+func rewriteValueAMD64_OpAMD64MFENCE(v *Value) bool {
+	v_0 := v.Args[0]
+	// match: (MFENCE (MFENCE mem))
+	// result: (MFENCE mem)
+	for {
+		if v_0.Op != OpAMD64MFENCE {
+			break
+		}
+		mem := v_0.Args[0]
+		v.reset(OpAMD64MFENCE)
+		v.AddArg(mem)
 		return true
 	}
 	return false
@@ -65957,6 +66062,40 @@ func rewriteValueAMD64_OpAtomicAnd8(v *Value) bool {
 		return true
 	}
 }
+func rewriteValueAMD64_OpAtomicCompareAndExchange32(v *Value) bool {
+	v_3 := v.Args[3]
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicCompareAndExchange32 ptr old new_ mem)
+	// result: (CMPXCHGLlockValue ptr old new_ mem)
+	for {
+		ptr := v_0
+		old := v_1
+		new_ := v_2
+		mem := v_3
+		v.reset(OpAMD64CMPXCHGLlockValue)
+		v.AddArg4(ptr, old, new_, mem)
+		return true
+	}
+}
+func rewriteValueAMD64_OpAtomicCompareAndExchange64(v *Value) bool {
+	v_3 := v.Args[3]
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicCompareAndExchange64 ptr old new_ mem)
+	// result: (CMPXCHGQlockValue ptr old new_ mem)
+	for {
+		ptr := v_0
+		old := v_1
+		new_ := v_2
+		mem := v_3
+		v.reset(OpAMD64CMPXCHGQlockValue)
+		v.AddArg4(ptr, old, new_, mem)
+		return true
+	}
+}
 func rewriteValueAMD64_OpAtomicCompareAndSwap32(v *Value) bool {
 	v_3 := v.Args[3]
 	v_2 := v.Args[2]
@@ -66049,10 +66188,36 @@ func rewriteValueAMD64_OpAtomicLoad32(v *Value) bool {
 		return true
 	}
 }
+func rewriteValueAMD64_OpAtomicLoad32Relaxed(v *Value) bool {
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicLoad32Relaxed ptr mem)
+	// result: (MOVLatomicload ptr mem)
+	for {
+		ptr := v_0
+		mem := v_1
+		v.reset(OpAMD64MOVLatomicload)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+}
 func rewriteValueAMD64_OpAtomicLoad64(v *Value) bool {
 	v_1 := v.Args[1]
 	v_0 := v.Args[0]
 	// match: (AtomicLoad64 ptr mem)
+	// result: (MOVQatomicload ptr mem)
+	for {
+		ptr := v_0
+		mem := v_1
+		v.reset(OpAMD64MOVQatomicload)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+}
+func rewriteValueAMD64_OpAtomicLoad64Relaxed(v *Value) bool {
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicLoad64Relaxed ptr mem)
 	// result: (MOVQatomicload ptr mem)
 	for {
 		ptr := v_0
@@ -66075,10 +66240,36 @@ func rewriteValueAMD64_OpAtomicLoad8(v *Value) bool {
 		return true
 	}
 }
+func rewriteValueAMD64_OpAtomicLoad8Relaxed(v *Value) bool {
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicLoad8Relaxed ptr mem)
+	// result: (MOVBatomicload ptr mem)
+	for {
+		ptr := v_0
+		mem := v_1
+		v.reset(OpAMD64MOVBatomicload)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+}
 func rewriteValueAMD64_OpAtomicLoadPtr(v *Value) bool {
 	v_1 := v.Args[1]
 	v_0 := v.Args[0]
 	// match: (AtomicLoadPtr ptr mem)
+	// result: (MOVQatomicload ptr mem)
+	for {
+		ptr := v_0
+		mem := v_1
+		v.reset(OpAMD64MOVQatomicload)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+}
+func rewriteValueAMD64_OpAtomicLoadPtrRelaxed(v *Value) bool {
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicLoadPtrRelaxed ptr mem)
 	// result: (MOVQatomicload ptr mem)
 	for {
 		ptr := v_0
@@ -66167,6 +66358,21 @@ func rewriteValueAMD64_OpAtomicStore32(v *Value) bool {
 		return true
 	}
 }
+func rewriteValueAMD64_OpAtomicStore32Relaxed(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicStore32Relaxed ptr val mem)
+	// result: (MOVLstore ptr val mem)
+	for {
+		ptr := v_0
+		val := v_1
+		mem := v_2
+		v.reset(OpAMD64MOVLstore)
+		v.AddArg3(ptr, val, mem)
+		return true
+	}
+}
 func rewriteValueAMD64_OpAtomicStore64(v *Value) bool {
 	v_2 := v.Args[2]
 	v_1 := v.Args[1]
@@ -66183,6 +66389,21 @@ func rewriteValueAMD64_OpAtomicStore64(v *Value) bool {
 		v0 := b.NewValue0(v.Pos, OpAMD64XCHGQ, types.NewTuple(typ.UInt64, types.TypeMem))
 		v0.AddArg3(val, ptr, mem)
 		v.AddArg(v0)
+		return true
+	}
+}
+func rewriteValueAMD64_OpAtomicStore64Relaxed(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicStore64Relaxed ptr val mem)
+	// result: (MOVQstore ptr val mem)
+	for {
+		ptr := v_0
+		val := v_1
+		mem := v_2
+		v.reset(OpAMD64MOVQstore)
+		v.AddArg3(ptr, val, mem)
 		return true
 	}
 }
@@ -66205,6 +66426,21 @@ func rewriteValueAMD64_OpAtomicStore8(v *Value) bool {
 		return true
 	}
 }
+func rewriteValueAMD64_OpAtomicStore8Relaxed(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicStore8Relaxed ptr val mem)
+	// result: (MOVBstore ptr val mem)
+	for {
+		ptr := v_0
+		val := v_1
+		mem := v_2
+		v.reset(OpAMD64MOVBstore)
+		v.AddArg3(ptr, val, mem)
+		return true
+	}
+}
 func rewriteValueAMD64_OpAtomicStorePtrNoWB(v *Value) bool {
 	v_2 := v.Args[2]
 	v_1 := v.Args[1]
@@ -66221,6 +66457,51 @@ func rewriteValueAMD64_OpAtomicStorePtrNoWB(v *Value) bool {
 		v0 := b.NewValue0(v.Pos, OpAMD64XCHGQ, types.NewTuple(typ.BytePtr, types.TypeMem))
 		v0.AddArg3(val, ptr, mem)
 		v.AddArg(v0)
+		return true
+	}
+}
+func rewriteValueAMD64_OpAtomicStorePtrRelaxedNoWB(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicStorePtrRelaxedNoWB ptr val mem)
+	// result: (MOVQstore ptr val mem)
+	for {
+		ptr := v_0
+		val := v_1
+		mem := v_2
+		v.reset(OpAMD64MOVQstore)
+		v.AddArg3(ptr, val, mem)
+		return true
+	}
+}
+func rewriteValueAMD64_OpAtomicXor32value(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicXor32value ptr val mem)
+	// result: (LoweredAtomicXor32 ptr val mem)
+	for {
+		ptr := v_0
+		val := v_1
+		mem := v_2
+		v.reset(OpAMD64LoweredAtomicXor32)
+		v.AddArg3(ptr, val, mem)
+		return true
+	}
+}
+func rewriteValueAMD64_OpAtomicXor64value(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicXor64value ptr val mem)
+	// result: (LoweredAtomicXor64 ptr val mem)
+	for {
+		ptr := v_0
+		val := v_1
+		mem := v_2
+		v.reset(OpAMD64LoweredAtomicXor64)
+		v.AddArg3(ptr, val, mem)
 		return true
 	}
 }
@@ -75855,6 +76136,42 @@ func rewriteValueAMD64_OpSelect1(v *Value) bool {
 			break
 		}
 		v.reset(OpAMD64ORLlock)
+		v.AddArg3(ptr, val, mem)
+		return true
+	}
+	// match: (Select1 a:(LoweredAtomicXor64 ptr val mem))
+	// cond: a.Uses == 1 && clobber(a)
+	// result: (XORQlock ptr val mem)
+	for {
+		a := v_0
+		if a.Op != OpAMD64LoweredAtomicXor64 {
+			break
+		}
+		mem := a.Args[2]
+		ptr := a.Args[0]
+		val := a.Args[1]
+		if !(a.Uses == 1 && clobber(a)) {
+			break
+		}
+		v.reset(OpAMD64XORQlock)
+		v.AddArg3(ptr, val, mem)
+		return true
+	}
+	// match: (Select1 a:(LoweredAtomicXor32 ptr val mem))
+	// cond: a.Uses == 1 && clobber(a)
+	// result: (XORLlock ptr val mem)
+	for {
+		a := v_0
+		if a.Op != OpAMD64LoweredAtomicXor32 {
+			break
+		}
+		mem := a.Args[2]
+		ptr := a.Args[0]
+		val := a.Args[1]
+		if !(a.Uses == 1 && clobber(a)) {
+			break
+		}
+		v.reset(OpAMD64XORLlock)
 		v.AddArg3(ptr, val, mem)
 		return true
 	}

--- a/src/cmd/compile/internal/ssa/rewriteARM64.go
+++ b/src/cmd/compile/internal/ssa/rewriteARM64.go
@@ -86,6 +86,8 @@ func rewriteValueARM64(v *Value) bool {
 		return rewriteValueARM64_OpARM64DIV(v)
 	case OpARM64DIVW:
 		return rewriteValueARM64_OpARM64DIVW(v)
+	case OpARM64DMB:
+		return rewriteValueARM64_OpARM64DMB(v)
 	case OpARM64EON:
 		return rewriteValueARM64_OpARM64EON(v)
 	case OpARM64EONshiftLL:
@@ -471,6 +473,18 @@ func rewriteValueARM64(v *Value) bool {
 	case OpAtomicAnd8valueVariant:
 		v.Op = OpARM64LoweredAtomicAnd8Variant
 		return true
+	case OpAtomicCompareAndExchange32:
+		v.Op = OpARM64LoweredAtomicCax32
+		return true
+	case OpAtomicCompareAndExchange32Variant:
+		v.Op = OpARM64LoweredAtomicCax32Variant
+		return true
+	case OpAtomicCompareAndExchange64:
+		v.Op = OpARM64LoweredAtomicCax64
+		return true
+	case OpAtomicCompareAndExchange64Variant:
+		v.Op = OpARM64LoweredAtomicCax64Variant
+		return true
 	case OpAtomicCompareAndSwap32:
 		v.Op = OpARM64LoweredAtomicCas32
 		return true
@@ -504,15 +518,23 @@ func rewriteValueARM64(v *Value) bool {
 	case OpAtomicLoad32:
 		v.Op = OpARM64LDARW
 		return true
+	case OpAtomicLoad32Relaxed:
+		return rewriteValueARM64_OpAtomicLoad32Relaxed(v)
 	case OpAtomicLoad64:
 		v.Op = OpARM64LDAR
 		return true
+	case OpAtomicLoad64Relaxed:
+		return rewriteValueARM64_OpAtomicLoad64Relaxed(v)
 	case OpAtomicLoad8:
 		v.Op = OpARM64LDARB
 		return true
+	case OpAtomicLoad8Relaxed:
+		return rewriteValueARM64_OpAtomicLoad8Relaxed(v)
 	case OpAtomicLoadPtr:
 		v.Op = OpARM64LDAR
 		return true
+	case OpAtomicLoadPtrRelaxed:
+		return rewriteValueARM64_OpAtomicLoadPtrRelaxed(v)
 	case OpAtomicOr32value:
 		v.Op = OpARM64LoweredAtomicOr32
 		return true
@@ -534,14 +556,34 @@ func rewriteValueARM64(v *Value) bool {
 	case OpAtomicStore32:
 		v.Op = OpARM64STLRW
 		return true
+	case OpAtomicStore32Relaxed:
+		return rewriteValueARM64_OpAtomicStore32Relaxed(v)
 	case OpAtomicStore64:
 		v.Op = OpARM64STLR
 		return true
+	case OpAtomicStore64Relaxed:
+		return rewriteValueARM64_OpAtomicStore64Relaxed(v)
 	case OpAtomicStore8:
 		v.Op = OpARM64STLRB
 		return true
+	case OpAtomicStore8Relaxed:
+		return rewriteValueARM64_OpAtomicStore8Relaxed(v)
 	case OpAtomicStorePtrNoWB:
 		v.Op = OpARM64STLR
+		return true
+	case OpAtomicStorePtrRelaxedNoWB:
+		return rewriteValueARM64_OpAtomicStorePtrRelaxedNoWB(v)
+	case OpAtomicXor32value:
+		v.Op = OpARM64LoweredAtomicXor32
+		return true
+	case OpAtomicXor32valueVariant:
+		v.Op = OpARM64LoweredAtomicXor32Variant
+		return true
+	case OpAtomicXor64value:
+		v.Op = OpARM64LoweredAtomicXor64
+		return true
+	case OpAtomicXor64valueVariant:
+		v.Op = OpARM64LoweredAtomicXor64Variant
 		return true
 	case OpAvg64u:
 		return rewriteValueARM64_OpAvg64u(v)
@@ -4042,6 +4084,95 @@ func rewriteValueARM64_OpARM64DIVW(v *Value) bool {
 		}
 		v.reset(OpARM64MOVDconst)
 		v.AuxInt = int64ToAuxInt(int64(uint32(int32(c) / int32(d))))
+		return true
+	}
+	return false
+}
+func rewriteValueARM64_OpARM64DMB(v *Value) bool {
+	v_0 := v.Args[0]
+	// match: (DMB [a] (DMB [a] mem))
+	// result: (DMB [a] mem)
+	for {
+		a := auxIntToInt64(v.AuxInt)
+		if v_0.Op != OpARM64DMB || auxIntToInt64(v_0.AuxInt) != a {
+			break
+		}
+		mem := v_0.Args[0]
+		v.reset(OpARM64DMB)
+		v.AuxInt = int64ToAuxInt(a)
+		v.AddArg(mem)
+		return true
+	}
+	// match: (DMB [0xB] (DMB [0x9] mem))
+	// result: (DMB [0xB] mem)
+	for {
+		if auxIntToInt64(v.AuxInt) != 0xB || v_0.Op != OpARM64DMB || auxIntToInt64(v_0.AuxInt) != 0x9 {
+			break
+		}
+		mem := v_0.Args[0]
+		v.reset(OpARM64DMB)
+		v.AuxInt = int64ToAuxInt(0xB)
+		v.AddArg(mem)
+		return true
+	}
+	// match: (DMB [0xB] (DMB [0xA] mem))
+	// result: (DMB [0xB] mem)
+	for {
+		if auxIntToInt64(v.AuxInt) != 0xB || v_0.Op != OpARM64DMB || auxIntToInt64(v_0.AuxInt) != 0xA {
+			break
+		}
+		mem := v_0.Args[0]
+		v.reset(OpARM64DMB)
+		v.AuxInt = int64ToAuxInt(0xB)
+		v.AddArg(mem)
+		return true
+	}
+	// match: (DMB [0x9] (DMB [0xB] mem))
+	// result: (DMB [0xB] mem)
+	for {
+		if auxIntToInt64(v.AuxInt) != 0x9 || v_0.Op != OpARM64DMB || auxIntToInt64(v_0.AuxInt) != 0xB {
+			break
+		}
+		mem := v_0.Args[0]
+		v.reset(OpARM64DMB)
+		v.AuxInt = int64ToAuxInt(0xB)
+		v.AddArg(mem)
+		return true
+	}
+	// match: (DMB [0xA] (DMB [0xB] mem))
+	// result: (DMB [0xB] mem)
+	for {
+		if auxIntToInt64(v.AuxInt) != 0xA || v_0.Op != OpARM64DMB || auxIntToInt64(v_0.AuxInt) != 0xB {
+			break
+		}
+		mem := v_0.Args[0]
+		v.reset(OpARM64DMB)
+		v.AuxInt = int64ToAuxInt(0xB)
+		v.AddArg(mem)
+		return true
+	}
+	// match: (DMB [0x9] (DMB [0xA] mem))
+	// result: (DMB [0xB] mem)
+	for {
+		if auxIntToInt64(v.AuxInt) != 0x9 || v_0.Op != OpARM64DMB || auxIntToInt64(v_0.AuxInt) != 0xA {
+			break
+		}
+		mem := v_0.Args[0]
+		v.reset(OpARM64DMB)
+		v.AuxInt = int64ToAuxInt(0xB)
+		v.AddArg(mem)
+		return true
+	}
+	// match: (DMB [0xA] (DMB [0x9] mem))
+	// result: (DMB [0xB] mem)
+	for {
+		if auxIntToInt64(v.AuxInt) != 0xA || v_0.Op != OpARM64DMB || auxIntToInt64(v_0.AuxInt) != 0x9 {
+			break
+		}
+		mem := v_0.Args[0]
+		v.reset(OpARM64DMB)
+		v.AuxInt = int64ToAuxInt(0xB)
+		v.AddArg(mem)
 		return true
 	}
 	return false
@@ -16942,6 +17073,118 @@ func rewriteValueARM64_OpAddr(v *Value) bool {
 		v.reset(OpARM64MOVDaddr)
 		v.Aux = symToAux(sym)
 		v.AddArg(base)
+		return true
+	}
+}
+func rewriteValueARM64_OpAtomicLoad32Relaxed(v *Value) bool {
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicLoad32Relaxed ptr mem)
+	// result: (LoweredAtomicLoad32Relaxed ptr mem)
+	for {
+		ptr := v_0
+		mem := v_1
+		v.reset(OpARM64LoweredAtomicLoad32Relaxed)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+}
+func rewriteValueARM64_OpAtomicLoad64Relaxed(v *Value) bool {
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicLoad64Relaxed ptr mem)
+	// result: (LoweredAtomicLoad64Relaxed ptr mem)
+	for {
+		ptr := v_0
+		mem := v_1
+		v.reset(OpARM64LoweredAtomicLoad64Relaxed)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+}
+func rewriteValueARM64_OpAtomicLoad8Relaxed(v *Value) bool {
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicLoad8Relaxed ptr mem)
+	// result: (LoweredAtomicLoad8Relaxed ptr mem)
+	for {
+		ptr := v_0
+		mem := v_1
+		v.reset(OpARM64LoweredAtomicLoad8Relaxed)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+}
+func rewriteValueARM64_OpAtomicLoadPtrRelaxed(v *Value) bool {
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicLoadPtrRelaxed ptr mem)
+	// result: (LoweredAtomicLoad64Relaxed ptr mem)
+	for {
+		ptr := v_0
+		mem := v_1
+		v.reset(OpARM64LoweredAtomicLoad64Relaxed)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+}
+func rewriteValueARM64_OpAtomicStore32Relaxed(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicStore32Relaxed ptr val mem)
+	// result: (LoweredAtomicStore32Relaxed ptr val mem)
+	for {
+		ptr := v_0
+		val := v_1
+		mem := v_2
+		v.reset(OpARM64LoweredAtomicStore32Relaxed)
+		v.AddArg3(ptr, val, mem)
+		return true
+	}
+}
+func rewriteValueARM64_OpAtomicStore64Relaxed(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicStore64Relaxed ptr val mem)
+	// result: (LoweredAtomicStore64Relaxed ptr val mem)
+	for {
+		ptr := v_0
+		val := v_1
+		mem := v_2
+		v.reset(OpARM64LoweredAtomicStore64Relaxed)
+		v.AddArg3(ptr, val, mem)
+		return true
+	}
+}
+func rewriteValueARM64_OpAtomicStore8Relaxed(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicStore8Relaxed ptr val mem)
+	// result: (LoweredAtomicStore8Relaxed ptr val mem)
+	for {
+		ptr := v_0
+		val := v_1
+		mem := v_2
+		v.reset(OpARM64LoweredAtomicStore8Relaxed)
+		v.AddArg3(ptr, val, mem)
+		return true
+	}
+}
+func rewriteValueARM64_OpAtomicStorePtrRelaxedNoWB(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicStorePtrRelaxedNoWB ptr val mem)
+	// result: (LoweredAtomicStore64Relaxed ptr val mem)
+	for {
+		ptr := v_0
+		val := v_1
+		mem := v_2
+		v.reset(OpARM64LoweredAtomicStore64Relaxed)
+		v.AddArg3(ptr, val, mem)
 		return true
 	}
 }

--- a/src/cmd/compile/internal/ssa/rewritegeneric.go
+++ b/src/cmd/compile/internal/ssa/rewritegeneric.go
@@ -38,6 +38,46 @@ func rewriteValuegeneric(v *Value) bool {
 		return rewriteValuegeneric_OpAndB(v)
 	case OpArraySelect:
 		return rewriteValuegeneric_OpArraySelect(v)
+	case OpAtomicAdd32:
+		return rewriteValuegeneric_OpAtomicAdd32(v)
+	case OpAtomicAdd32Variant:
+		return rewriteValuegeneric_OpAtomicAdd32Variant(v)
+	case OpAtomicAdd64:
+		return rewriteValuegeneric_OpAtomicAdd64(v)
+	case OpAtomicAdd64Variant:
+		return rewriteValuegeneric_OpAtomicAdd64Variant(v)
+	case OpAtomicAnd32value:
+		return rewriteValuegeneric_OpAtomicAnd32value(v)
+	case OpAtomicAnd32valueVariant:
+		return rewriteValuegeneric_OpAtomicAnd32valueVariant(v)
+	case OpAtomicAnd64value:
+		return rewriteValuegeneric_OpAtomicAnd64value(v)
+	case OpAtomicAnd64valueVariant:
+		return rewriteValuegeneric_OpAtomicAnd64valueVariant(v)
+	case OpAtomicAnd8value:
+		return rewriteValuegeneric_OpAtomicAnd8value(v)
+	case OpAtomicAnd8valueVariant:
+		return rewriteValuegeneric_OpAtomicAnd8valueVariant(v)
+	case OpAtomicOr32value:
+		return rewriteValuegeneric_OpAtomicOr32value(v)
+	case OpAtomicOr32valueVariant:
+		return rewriteValuegeneric_OpAtomicOr32valueVariant(v)
+	case OpAtomicOr64value:
+		return rewriteValuegeneric_OpAtomicOr64value(v)
+	case OpAtomicOr64valueVariant:
+		return rewriteValuegeneric_OpAtomicOr64valueVariant(v)
+	case OpAtomicOr8value:
+		return rewriteValuegeneric_OpAtomicOr8value(v)
+	case OpAtomicOr8valueVariant:
+		return rewriteValuegeneric_OpAtomicOr8valueVariant(v)
+	case OpAtomicXor32value:
+		return rewriteValuegeneric_OpAtomicXor32value(v)
+	case OpAtomicXor32valueVariant:
+		return rewriteValuegeneric_OpAtomicXor32valueVariant(v)
+	case OpAtomicXor64value:
+		return rewriteValuegeneric_OpAtomicXor64value(v)
+	case OpAtomicXor64valueVariant:
+		return rewriteValuegeneric_OpAtomicXor64valueVariant(v)
 	case OpBitLen16:
 		return rewriteValuegeneric_OpBitLen16(v)
 	case OpBitLen32:
@@ -5533,6 +5573,366 @@ func rewriteValuegeneric_OpArraySelect(v *Value) bool {
 		x := v_0.Args[0]
 		v.reset(OpIData)
 		v.AddArg(x)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicAdd32(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicAdd32 ptr (Const32 [0]) mem)
+	// result: (AtomicLoad32 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst32 || auxIntToInt32(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad32)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicAdd32Variant(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicAdd32Variant ptr (Const32 [0]) mem)
+	// result: (AtomicLoad32 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst32 || auxIntToInt32(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad32)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicAdd64(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicAdd64 ptr (Const64 [0]) mem)
+	// result: (AtomicLoad64 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst64 || auxIntToInt64(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad64)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicAdd64Variant(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicAdd64Variant ptr (Const64 [0]) mem)
+	// result: (AtomicLoad64 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst64 || auxIntToInt64(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad64)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicAnd32value(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicAnd32value ptr (Const32 [-1]) mem)
+	// result: (AtomicLoad32 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst32 || auxIntToInt32(v_1.AuxInt) != -1 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad32)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicAnd32valueVariant(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicAnd32valueVariant ptr (Const32 [-1]) mem)
+	// result: (AtomicLoad32 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst32 || auxIntToInt32(v_1.AuxInt) != -1 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad32)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicAnd64value(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicAnd64value ptr (Const64 [-1]) mem)
+	// result: (AtomicLoad64 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst64 || auxIntToInt64(v_1.AuxInt) != -1 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad64)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicAnd64valueVariant(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicAnd64valueVariant ptr (Const64 [-1]) mem)
+	// result: (AtomicLoad64 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst64 || auxIntToInt64(v_1.AuxInt) != -1 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad64)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicAnd8value(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicAnd8value ptr (Const8 [-1]) mem)
+	// result: (AtomicLoad8 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst8 || auxIntToInt8(v_1.AuxInt) != -1 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad8)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicAnd8valueVariant(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicAnd8valueVariant ptr (Const8 [-1]) mem)
+	// result: (AtomicLoad8 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst8 || auxIntToInt8(v_1.AuxInt) != -1 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad8)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicOr32value(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicOr32value ptr (Const32 [0]) mem)
+	// result: (AtomicLoad32 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst32 || auxIntToInt32(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad32)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicOr32valueVariant(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicOr32valueVariant ptr (Const32 [0]) mem)
+	// result: (AtomicLoad32 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst32 || auxIntToInt32(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad32)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicOr64value(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicOr64value ptr (Const64 [0]) mem)
+	// result: (AtomicLoad64 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst64 || auxIntToInt64(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad64)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicOr64valueVariant(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicOr64valueVariant ptr (Const64 [0]) mem)
+	// result: (AtomicLoad64 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst64 || auxIntToInt64(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad64)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicOr8value(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicOr8value ptr (Const8 [0]) mem)
+	// result: (AtomicLoad8 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst8 || auxIntToInt8(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad8)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicOr8valueVariant(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicOr8valueVariant ptr (Const8 [0]) mem)
+	// result: (AtomicLoad8 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst8 || auxIntToInt8(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad8)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicXor32value(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicXor32value ptr (Const32 [0]) mem)
+	// result: (AtomicLoad32 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst32 || auxIntToInt32(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad32)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicXor32valueVariant(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicXor32valueVariant ptr (Const32 [0]) mem)
+	// result: (AtomicLoad32 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst32 || auxIntToInt32(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad32)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicXor64value(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicXor64value ptr (Const64 [0]) mem)
+	// result: (AtomicLoad64 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst64 || auxIntToInt64(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad64)
+		v.AddArg2(ptr, mem)
+		return true
+	}
+	return false
+}
+func rewriteValuegeneric_OpAtomicXor64valueVariant(v *Value) bool {
+	v_2 := v.Args[2]
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	// match: (AtomicXor64valueVariant ptr (Const64 [0]) mem)
+	// result: (AtomicLoad64 ptr mem)
+	for {
+		ptr := v_0
+		if v_1.Op != OpConst64 || auxIntToInt64(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpAtomicLoad64)
+		v.AddArg2(ptr, mem)
 		return true
 	}
 	return false

--- a/src/cmd/compile/internal/ssagen/intrinsics.go
+++ b/src/cmd/compile/internal/ssagen/intrinsics.go
@@ -1316,6 +1316,871 @@ func initIntrinsics(cfg *intrinsicBuildConfig) {
 	alias("sync/atomic", "OrUint64", "internal/runtime/atomic", "Or64", sys.ArchARM64, sys.ArchAMD64, sys.ArchLoong64)
 	alias("sync/atomic", "OrUintptr", "internal/runtime/atomic", "Or64", sys.ArchARM64, sys.ArchAMD64, sys.ArchLoong64)
 
+	/******** code.hybscloud.com/atomix ********/
+
+	// atomix intrinsics for code.hybscloud.com/atomix/internal/arch package.
+	// These provide zero-overhead atomic operations with explicit memory ordering.
+	// On x86-64 TSO, all orderings compile to the same instructions (LOCK prefix).
+	// On ARM64, different orderings use different instruction suffixes.
+
+	// Helper for atomix Swap intrinsics
+	atomixSwap32 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicExchange32, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT32], v)
+	}
+	atomixSwap32u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicExchange32, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT32], v)
+	}
+	atomixSwap64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicExchange64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT64], v)
+	}
+	atomixSwap64u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicExchange64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT64], v)
+	}
+	atomixSwapUintptr := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicExchange64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINTPTR], v)
+	}
+	atomixSwapPointer := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicExchange64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUNSAFEPTR], v)
+	}
+
+	// ARM64 LSE-guarded intrinsics for atomix use runtime detection via makeAtomicGuardedIntrinsicARM64.
+	// This ensures LSE instructions (SWPAL, LDADDAL, etc.) are used on Graviton4 and other modern ARM64
+	// CPUs that support LSE, while falling back to LL/SC loops on older hardware.
+	// Note: The atomicEmitterARM64 defined earlier in this file is reused for atomix operations.
+
+	// Swap operations - Relaxed (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt32Relaxed", atomixSwap32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint32Relaxed", atomixSwap32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt64Relaxed", atomixSwap64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint64Relaxed", atomixSwap64u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUintptrRelaxed", atomixSwapUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapPointerRelaxed", atomixSwapPointer, sys.AMD64)
+	// Swap operations - Relaxed (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange32, ssa.OpAtomicExchange32Variant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange32, ssa.OpAtomicExchange32Variant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUintptrRelaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapPointerRelaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUNSAFEPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Swap operations - Acquire (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt32Acquire", atomixSwap32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint32Acquire", atomixSwap32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt64Acquire", atomixSwap64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint64Acquire", atomixSwap64u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUintptrAcquire", atomixSwapUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapPointerAcquire", atomixSwapPointer, sys.AMD64)
+	// Swap operations - Acquire (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange32, ssa.OpAtomicExchange32Variant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange32, ssa.OpAtomicExchange32Variant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUintptrAcquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapPointerAcquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUNSAFEPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Swap operations - Release (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt32Release", atomixSwap32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint32Release", atomixSwap32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt64Release", atomixSwap64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint64Release", atomixSwap64u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUintptrRelease", atomixSwapUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapPointerRelease", atomixSwapPointer, sys.AMD64)
+	// Swap operations - Release (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange32, ssa.OpAtomicExchange32Variant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange32, ssa.OpAtomicExchange32Variant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUintptrRelease",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapPointerRelease",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUNSAFEPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Swap operations - AcqRel (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt32AcqRel", atomixSwap32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint32AcqRel", atomixSwap32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt64AcqRel", atomixSwap64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint64AcqRel", atomixSwap64u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUintptrAcqRel", atomixSwapUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapPointerAcqRel", atomixSwapPointer, sys.AMD64)
+	// Swap operations - AcqRel (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange32, ssa.OpAtomicExchange32Variant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange32, ssa.OpAtomicExchange32Variant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapInt64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUint64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapUintptrAcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "SwapPointerAcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicExchange64, ssa.OpAtomicExchange64Variant, types.TUNSAFEPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Helper for atomix CAS intrinsics (returns bool) - AMD64 version
+	atomixCas32AMD64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue4(ssa.OpAtomicCompareAndSwap32, types.NewTuple(types.Types[types.TBOOL], types.TypeMem), args[0], args[1], args[2], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TBOOL], v)
+	}
+	atomixCas64AMD64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue4(ssa.OpAtomicCompareAndSwap64, types.NewTuple(types.Types[types.TBOOL], types.TypeMem), args[0], args[1], args[2], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TBOOL], v)
+	}
+
+	// Helper for atomix CAS intrinsics - ARM64 version with LSE support
+	atomixCasEmitterARM64 := func(s *state, n *ir.CallExpr, args []*ssa.Value, op ssa.Op, typ types.Kind, needReturn bool) {
+		v := s.newValue4(op, types.NewTuple(types.Types[types.TBOOL], types.TypeMem), args[0], args[1], args[2], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		if needReturn {
+			s.vars[n] = s.newValue1(ssa.OpSelect0, types.Types[typ], v)
+		}
+	}
+
+	// CAS operations - Relaxed
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt32Relaxed", atomixCas32AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint32Relaxed", atomixCas32AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt64Relaxed", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint64Relaxed", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUintptrRelaxed", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasPointerRelaxed", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap32, ssa.OpAtomicCompareAndSwap32Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap32, ssa.OpAtomicCompareAndSwap32Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUintptrRelaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasPointerRelaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+
+	// CAS operations - Acquire
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt32Acquire", atomixCas32AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint32Acquire", atomixCas32AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt64Acquire", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint64Acquire", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUintptrAcquire", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasPointerAcquire", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap32, ssa.OpAtomicCompareAndSwap32Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap32, ssa.OpAtomicCompareAndSwap32Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUintptrAcquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasPointerAcquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+
+	// CAS operations - Release
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt32Release", atomixCas32AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint32Release", atomixCas32AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt64Release", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint64Release", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUintptrRelease", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasPointerRelease", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap32, ssa.OpAtomicCompareAndSwap32Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap32, ssa.OpAtomicCompareAndSwap32Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUintptrRelease",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasPointerRelease",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+
+	// CAS operations - AcqRel
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt32AcqRel", atomixCas32AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint32AcqRel", atomixCas32AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt64AcqRel", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint64AcqRel", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUintptrAcqRel", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasPointerAcqRel", atomixCas64AMD64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap32, ssa.OpAtomicCompareAndSwap32Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap32, ssa.OpAtomicCompareAndSwap32Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasInt64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUint64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasUintptrAcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CasPointerAcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicCompareAndSwap64, ssa.OpAtomicCompareAndSwap64Variant, types.TBOOL, atomixCasEmitterARM64), sys.ARM64)
+
+	// Helper for atomix CAX intrinsics (returns old value)
+	atomixCax32 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue4(ssa.OpAtomicCompareAndExchange32, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], args[2], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT32], v)
+	}
+	atomixCax32u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue4(ssa.OpAtomicCompareAndExchange32, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], args[2], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT32], v)
+	}
+	atomixCax64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue4(ssa.OpAtomicCompareAndExchange64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], args[2], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT64], v)
+	}
+	atomixCax64u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue4(ssa.OpAtomicCompareAndExchange64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], args[2], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT64], v)
+	}
+	atomixCaxUintptr := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue4(ssa.OpAtomicCompareAndExchange64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], args[2], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINTPTR], v)
+	}
+	atomixCaxPointer := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue4(ssa.OpAtomicCompareAndExchange64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], args[2], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUNSAFEPTR], v)
+	}
+
+	// CAX operations - Relaxed
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxInt32Relaxed", atomixCax32, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUint32Relaxed", atomixCax32u, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxInt64Relaxed", atomixCax64, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUint64Relaxed", atomixCax64u, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUintptrRelaxed", atomixCaxUintptr, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxPointerRelaxed", atomixCaxPointer, sys.AMD64, sys.ARM64)
+
+	// CAX operations - Acquire
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxInt32Acquire", atomixCax32, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUint32Acquire", atomixCax32u, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxInt64Acquire", atomixCax64, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUint64Acquire", atomixCax64u, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUintptrAcquire", atomixCaxUintptr, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxPointerAcquire", atomixCaxPointer, sys.AMD64, sys.ARM64)
+
+	// CAX operations - Release
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxInt32Release", atomixCax32, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUint32Release", atomixCax32u, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxInt64Release", atomixCax64, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUint64Release", atomixCax64u, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUintptrRelease", atomixCaxUintptr, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxPointerRelease", atomixCaxPointer, sys.AMD64, sys.ARM64)
+
+	// CAX operations - AcqRel
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxInt32AcqRel", atomixCax32, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUint32AcqRel", atomixCax32u, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxInt64AcqRel", atomixCax64, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUint64AcqRel", atomixCax64u, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxUintptrAcqRel", atomixCaxUintptr, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "CaxPointerAcqRel", atomixCaxPointer, sys.AMD64, sys.ARM64)
+
+	// Helper for atomix Add intrinsics (returns new value)
+	atomixAdd32 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicAdd32, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT32], v)
+	}
+	atomixAdd32u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicAdd32, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT32], v)
+	}
+	atomixAdd64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicAdd64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT64], v)
+	}
+	atomixAdd64u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicAdd64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT64], v)
+	}
+	atomixAddUintptr := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicAdd64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINTPTR], v)
+	}
+
+	// Add operations - Relaxed (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt32Relaxed", atomixAdd32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint32Relaxed", atomixAdd32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt64Relaxed", atomixAdd64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint64Relaxed", atomixAdd64u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUintptrRelaxed", atomixAddUintptr, sys.AMD64)
+	// Add operations - Relaxed (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd32, ssa.OpAtomicAdd32Variant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd32, ssa.OpAtomicAdd32Variant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUintptrRelaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Add operations - Acquire (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt32Acquire", atomixAdd32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint32Acquire", atomixAdd32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt64Acquire", atomixAdd64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint64Acquire", atomixAdd64u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUintptrAcquire", atomixAddUintptr, sys.AMD64)
+	// Add operations - Acquire (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd32, ssa.OpAtomicAdd32Variant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd32, ssa.OpAtomicAdd32Variant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUintptrAcquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Add operations - Release (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt32Release", atomixAdd32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint32Release", atomixAdd32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt64Release", atomixAdd64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint64Release", atomixAdd64u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUintptrRelease", atomixAddUintptr, sys.AMD64)
+	// Add operations - Release (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd32, ssa.OpAtomicAdd32Variant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd32, ssa.OpAtomicAdd32Variant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUintptrRelease",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Add operations - AcqRel (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt32AcqRel", atomixAdd32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint32AcqRel", atomixAdd32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt64AcqRel", atomixAdd64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint64AcqRel", atomixAdd64u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUintptrAcqRel", atomixAddUintptr, sys.AMD64)
+	// Add operations - AcqRel (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd32, ssa.OpAtomicAdd32Variant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd32, ssa.OpAtomicAdd32Variant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddInt64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUint64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AddUintptrAcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAdd64, ssa.OpAtomicAdd64Variant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Helper for atomix And intrinsics (returns old value)
+	atomixAnd32 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicAnd32value, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT32], v)
+	}
+	atomixAnd32u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicAnd32value, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT32], v)
+	}
+	atomixAnd64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicAnd64value, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT64], v)
+	}
+	atomixAnd64u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicAnd64value, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT64], v)
+	}
+
+	// And operations - Relaxed (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt32Relaxed", atomixAnd32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint32Relaxed", atomixAnd32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt64Relaxed", atomixAnd64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint64Relaxed", atomixAnd64u, sys.AMD64)
+	// And operations - Relaxed (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd32value, ssa.OpAtomicAnd32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd32value, ssa.OpAtomicAnd32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// And operations - Acquire (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt32Acquire", atomixAnd32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint32Acquire", atomixAnd32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt64Acquire", atomixAnd64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint64Acquire", atomixAnd64u, sys.AMD64)
+	// And operations - Acquire (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd32value, ssa.OpAtomicAnd32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd32value, ssa.OpAtomicAnd32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// And operations - Release (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt32Release", atomixAnd32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint32Release", atomixAnd32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt64Release", atomixAnd64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint64Release", atomixAnd64u, sys.AMD64)
+	// And operations - Release (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd32value, ssa.OpAtomicAnd32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd32value, ssa.OpAtomicAnd32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// And operations - AcqRel (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt32AcqRel", atomixAnd32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint32AcqRel", atomixAnd32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt64AcqRel", atomixAnd64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint64AcqRel", atomixAnd64u, sys.AMD64)
+	// And operations - AcqRel (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd32value, ssa.OpAtomicAnd32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd32value, ssa.OpAtomicAnd32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndInt64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUint64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// Helper for atomix Or intrinsics (returns old value)
+	atomixOr32 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicOr32value, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT32], v)
+	}
+	atomixOr32u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicOr32value, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT32], v)
+	}
+	atomixOr64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicOr64value, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT64], v)
+	}
+	atomixOr64u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicOr64value, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT64], v)
+	}
+
+	// Or operations - Relaxed (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt32Relaxed", atomixOr32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint32Relaxed", atomixOr32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt64Relaxed", atomixOr64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint64Relaxed", atomixOr64u, sys.AMD64)
+	// Or operations - Relaxed (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr32value, ssa.OpAtomicOr32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr32value, ssa.OpAtomicOr32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// Or operations - Acquire (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt32Acquire", atomixOr32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint32Acquire", atomixOr32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt64Acquire", atomixOr64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint64Acquire", atomixOr64u, sys.AMD64)
+	// Or operations - Acquire (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr32value, ssa.OpAtomicOr32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr32value, ssa.OpAtomicOr32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// Or operations - Release (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt32Release", atomixOr32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint32Release", atomixOr32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt64Release", atomixOr64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint64Release", atomixOr64u, sys.AMD64)
+	// Or operations - Release (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr32value, ssa.OpAtomicOr32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr32value, ssa.OpAtomicOr32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// Or operations - AcqRel (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt32AcqRel", atomixOr32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint32AcqRel", atomixOr32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt64AcqRel", atomixOr64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint64AcqRel", atomixOr64u, sys.AMD64)
+	// Or operations - AcqRel (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr32value, ssa.OpAtomicOr32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr32value, ssa.OpAtomicOr32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrInt64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUint64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// Helper for atomix And/Or Uintptr intrinsics
+	atomixAndUintptr := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicAnd64value, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINTPTR], v)
+	}
+	atomixOrUintptr := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicOr64value, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINTPTR], v)
+	}
+
+	// And Uintptr operations - all orderings (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUintptrRelaxed", atomixAndUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUintptrAcquire", atomixAndUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUintptrRelease", atomixAndUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUintptrAcqRel", atomixAndUintptr, sys.AMD64)
+	// And Uintptr operations - all orderings (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUintptrRelaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUintptrAcquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUintptrRelease",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "AndUintptrAcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicAnd64value, ssa.OpAtomicAnd64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Or Uintptr operations - all orderings (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUintptrRelaxed", atomixOrUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUintptrAcquire", atomixOrUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUintptrRelease", atomixOrUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUintptrAcqRel", atomixOrUintptr, sys.AMD64)
+	// Or Uintptr operations - all orderings (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUintptrRelaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUintptrAcquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUintptrRelease",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "OrUintptrAcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicOr64value, ssa.OpAtomicOr64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Helper for atomix Xor intrinsics (returns old value)
+	atomixXor32 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicXor32value, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT32], v)
+	}
+	atomixXor32u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicXor32value, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT32], v)
+	}
+	atomixXor64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicXor64value, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT64], v)
+	}
+	atomixXor64u := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicXor64value, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT64], v)
+	}
+
+	// Xor operations - Relaxed (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt32Relaxed", atomixXor32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint32Relaxed", atomixXor32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt64Relaxed", atomixXor64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint64Relaxed", atomixXor64u, sys.AMD64)
+	// Xor operations - Relaxed (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor32value, ssa.OpAtomicXor32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint32Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor32value, ssa.OpAtomicXor32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint64Relaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// Xor operations - Acquire (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt32Acquire", atomixXor32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint32Acquire", atomixXor32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt64Acquire", atomixXor64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint64Acquire", atomixXor64u, sys.AMD64)
+	// Xor operations - Acquire (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor32value, ssa.OpAtomicXor32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint32Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor32value, ssa.OpAtomicXor32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint64Acquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// Xor operations - Release (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt32Release", atomixXor32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint32Release", atomixXor32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt64Release", atomixXor64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint64Release", atomixXor64u, sys.AMD64)
+	// Xor operations - Release (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor32value, ssa.OpAtomicXor32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint32Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor32value, ssa.OpAtomicXor32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint64Release",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// Xor operations - AcqRel (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt32AcqRel", atomixXor32, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint32AcqRel", atomixXor32u, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt64AcqRel", atomixXor64, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint64AcqRel", atomixXor64u, sys.AMD64)
+	// Xor operations - AcqRel (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor32value, ssa.OpAtomicXor32valueVariant, types.TINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint32AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor32value, ssa.OpAtomicXor32valueVariant, types.TUINT32, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorInt64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TINT64, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUint64AcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TUINT64, atomicEmitterARM64), sys.ARM64)
+
+	// Helper for atomix Xor Uintptr intrinsics
+	atomixXorUintptr := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue3(ssa.OpAtomicXor64value, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], args[1], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINTPTR], v)
+	}
+
+	// Xor Uintptr operations - all orderings (AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUintptrRelaxed", atomixXorUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUintptrAcquire", atomixXorUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUintptrRelease", atomixXorUintptr, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUintptrAcqRel", atomixXorUintptr, sys.AMD64)
+	// Xor Uintptr operations - all orderings (ARM64 with runtime LSE detection)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUintptrRelaxed",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUintptrAcquire",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUintptrRelease",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "XorUintptrAcqRel",
+		makeAtomicGuardedIntrinsicARM64(ssa.OpAtomicXor64value, ssa.OpAtomicXor64valueVariant, types.TUINTPTR, atomicEmitterARM64), sys.ARM64)
+
+	// Helper for atomix Load intrinsics (Acquire semantics - uses LDAR on ARM64)
+	atomixLoad32Acquire := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoad32, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT32], v)
+	}
+	atomixLoad32uAcquire := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoad32, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT32], v)
+	}
+	atomixLoad64Acquire := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoad64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT64], v)
+	}
+	atomixLoad64uAcquire := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoad64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT64], v)
+	}
+	atomixLoadUintptrAcquire := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoad64, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINTPTR], v)
+	}
+	atomixLoadPointerAcquire := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoadPtr, types.NewTuple(types.Types[types.TUNSAFEPTR], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUNSAFEPTR], v)
+	}
+
+	// Helper for atomix Load intrinsics (Relaxed semantics - uses plain MOV on ARM64)
+	atomixLoad32Relaxed := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoad32Relaxed, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT32], v)
+	}
+	atomixLoad32uRelaxed := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoad32Relaxed, types.NewTuple(types.Types[types.TUINT32], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT32], v)
+	}
+	atomixLoad64Relaxed := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoad64Relaxed, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TINT64], v)
+	}
+	atomixLoad64uRelaxed := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoad64Relaxed, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINT64], v)
+	}
+	atomixLoadUintptrRelaxed := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoad64Relaxed, types.NewTuple(types.Types[types.TUINT64], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUINTPTR], v)
+	}
+	atomixLoadPointerRelaxed := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		v := s.newValue2(ssa.OpAtomicLoadPtrRelaxed, types.NewTuple(types.Types[types.TUNSAFEPTR], types.TypeMem), args[0], s.mem())
+		s.vars[memVar] = s.newValue1(ssa.OpSelect1, types.TypeMem, v)
+		return s.newValue1(ssa.OpSelect0, types.Types[types.TUNSAFEPTR], v)
+	}
+
+	// Load operations - Relaxed (plain MOV on ARM64, no acquire semantics)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadInt32Relaxed", atomixLoad32Relaxed, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadUint32Relaxed", atomixLoad32uRelaxed, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadInt64Relaxed", atomixLoad64Relaxed, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadUint64Relaxed", atomixLoad64uRelaxed, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadUintptrRelaxed", atomixLoadUintptrRelaxed, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadPointerRelaxed", atomixLoadPointerRelaxed, sys.AMD64, sys.ARM64)
+
+	// Load operations - Acquire (LDAR on ARM64, same as regular atomic load on x86-64 TSO)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadInt32Acquire", atomixLoad32Acquire, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadUint32Acquire", atomixLoad32uAcquire, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadInt64Acquire", atomixLoad64Acquire, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadUint64Acquire", atomixLoad64uAcquire, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadUintptrAcquire", atomixLoadUintptrAcquire, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "LoadPointerAcquire", atomixLoadPointerAcquire, sys.AMD64, sys.ARM64)
+
+	// Helper for atomix Store intrinsics (Release semantics - STLR on ARM64, XCHG on x86)
+	atomixStore32Release := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue3(ssa.OpAtomicStore32, types.TypeMem, args[0], args[1], s.mem())
+		return nil
+	}
+	atomixStore64Release := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue3(ssa.OpAtomicStore64, types.TypeMem, args[0], args[1], s.mem())
+		return nil
+	}
+	atomixStoreUintptrRelease := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue3(ssa.OpAtomicStore64, types.TypeMem, args[0], args[1], s.mem())
+		return nil
+	}
+	atomixStorePointerRelease := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue3(ssa.OpAtomicStorePtrNoWB, types.TypeMem, args[0], args[1], s.mem())
+		return nil
+	}
+
+	// Helper for atomix Store intrinsics (Relaxed semantics - plain MOV on ARM64 and x86)
+	atomixStore32Relaxed := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue3(ssa.OpAtomicStore32Relaxed, types.TypeMem, args[0], args[1], s.mem())
+		return nil
+	}
+	atomixStore64Relaxed := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue3(ssa.OpAtomicStore64Relaxed, types.TypeMem, args[0], args[1], s.mem())
+		return nil
+	}
+	atomixStoreUintptrRelaxed := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue3(ssa.OpAtomicStore64Relaxed, types.TypeMem, args[0], args[1], s.mem())
+		return nil
+	}
+	atomixStorePointerRelaxed := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue3(ssa.OpAtomicStorePtrRelaxedNoWB, types.TypeMem, args[0], args[1], s.mem())
+		return nil
+	}
+
+	// Store operations - Relaxed (plain MOV on ARM64 and x86, no release semantics)
+	addF("code.hybscloud.com/atomix/internal/arch", "StoreInt32Relaxed", atomixStore32Relaxed, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "StoreUint32Relaxed", atomixStore32Relaxed, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "StoreInt64Relaxed", atomixStore64Relaxed, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "StoreUint64Relaxed", atomixStore64Relaxed, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "StoreUintptrRelaxed", atomixStoreUintptrRelaxed, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "StorePointerRelaxed", atomixStorePointerRelaxed, sys.AMD64, sys.ARM64)
+
+	// Store operations - Release (STLR on ARM64, XCHG on x86 for full barrier)
+	addF("code.hybscloud.com/atomix/internal/arch", "StoreInt32Release", atomixStore32Release, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "StoreUint32Release", atomixStore32Release, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "StoreInt64Release", atomixStore64Release, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "StoreUint64Release", atomixStore64Release, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "StoreUintptrRelease", atomixStoreUintptrRelease, sys.AMD64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "StorePointerRelease", atomixStorePointerRelease, sys.AMD64, sys.ARM64)
+
+	// Memory barrier intrinsics
+	// AMD64: TSO provides acquire/release automatically, only AcqRel needs MFENCE
+	atomixBarrierNoOp := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		return nil
+	}
+	atomixBarrierMFENCE := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue1(ssa.OpAMD64MFENCE, types.TypeMem, s.mem())
+		return nil
+	}
+	// ARM64: DMB with different options (0x9=ISHLD, 0xA=ISHST, 0xB=ISH)
+	atomixBarrierAcquireARM64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue1I(ssa.OpARM64DMB, types.TypeMem, 0x9, s.mem())
+		return nil
+	}
+	atomixBarrierReleaseARM64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue1I(ssa.OpARM64DMB, types.TypeMem, 0xA, s.mem())
+		return nil
+	}
+	atomixBarrierAcqRelARM64 := func(s *state, n *ir.CallExpr, args []*ssa.Value) *ssa.Value {
+		s.vars[memVar] = s.newValue1I(ssa.OpARM64DMB, types.TypeMem, 0xB, s.mem())
+		return nil
+	}
+	// Barrier operations - AMD64 (TSO: acquire/release are no-ops)
+	addF("code.hybscloud.com/atomix/internal/arch", "BarrierAcquire", atomixBarrierNoOp, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "BarrierRelease", atomixBarrierNoOp, sys.AMD64)
+	addF("code.hybscloud.com/atomix/internal/arch", "BarrierAcqRel", atomixBarrierMFENCE, sys.AMD64)
+	// Barrier operations - ARM64 (DMB with appropriate options)
+	addF("code.hybscloud.com/atomix/internal/arch", "BarrierAcquire", atomixBarrierAcquireARM64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "BarrierRelease", atomixBarrierReleaseARM64, sys.ARM64)
+	addF("code.hybscloud.com/atomix/internal/arch", "BarrierAcqRel", atomixBarrierAcqRelARM64, sys.ARM64)
+
 	/******** math/big ********/
 	alias("math/big", "mulWW", "math/bits", "Mul64", p8...)
 


### PR DESCRIPTION
## Summary

- Add compiler intrinsics for `code.hybscloud.com/atomix` package with explicit memory ordering support
- AMD64: Map all orderings to LOCK-prefixed instructions (TSO)
- ARM64: Use runtime LSE detection via `runtime.arm64HasATOMICS`
  - LSE path: SWPAL, LDADDAL, CASAL, LDCLRAL, LDSETAL, LDEORAL
  - Fallback: LDAXR/STLXR loops for older ARM64 CPUs
- Add barrier intrinsics (Acquire, Release, AcqRel, SeqCst)

## Test plan

- [x] Compiler builds successfully
- [x] ARM64 binary generates correct LSE-guarded assembly
- [x] Benchmarks verified on Graviton4 (c8g.large)