### PR TITLE
ci: fix watch-upstream to cherry-pick all atomix commits

### DIFF
--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -107,22 +107,28 @@ jobs:
           
           echo "Rebasing atomix onto ${TAG}..."
           
-          # Get the atomix commit (HEAD minus merge commits)
-          ATOMIX_COMMIT=$(git log --oneline --no-merges -1 --format="%H")
-          echo "Atomix commit: $ATOMIX_COMMIT"
-          
-          # Create new branch from upstream tag
+          # Find the upstream base tag that the current atomix branch forked from.
+          # This is the most recent go release tag reachable from HEAD.
+          BASE_TAG=$(git describe --tags --abbrev=0 --match 'go[0-9]*.[0-9]*.[0-9]*' --exclude '*-*' HEAD)
+          echo "Base upstream tag: ${BASE_TAG}"
+
+          # Collect all atomix commits on top of the base tag (oldest first).
+          mapfile -t ATOMIX_COMMITS < <(git rev-list --no-merges --reverse "${BASE_TAG}..HEAD")
+          echo "Atomix commits (${#ATOMIX_COMMITS[@]}):"
+          printf '  %s\n' "${ATOMIX_COMMITS[@]}"
+
+          if [ ${#ATOMIX_COMMITS[@]} -eq 0 ]; then
+            echo "rebase_success=false" >> $GITHUB_OUTPUT
+            echo "No atomix commits found above ${BASE_TAG}"
+            exit 0
+          fi
+
+          # Create new branch from the target upstream tag
           git checkout -b "atomix-${VERSION}" "${TAG}"
-          
-          # Cherry-pick atomix changes
-          if git cherry-pick "$ATOMIX_COMMIT"; then
+
+          # Cherry-pick all atomix commits in order
+          if git cherry-pick "${ATOMIX_COMMITS[@]}"; then
             echo "rebase_success=true" >> $GITHUB_OUTPUT
-            
-            # Update VERSION file to match upstream exactly
-            echo "${TAG}" > VERSION
-            git add VERSION
-            git commit --amend --no-edit
-            
             echo "Rebase successful for ${VERSION}"
           else
             echo "rebase_success=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -109,7 +109,18 @@ jobs:
           
           # Find the upstream base tag that the current atomix branch forked from.
           # This is the most recent go release tag reachable from HEAD.
+          # Handle failures explicitly so bash -e doesn't terminate the step before
+          # we can write rebase_success to $GITHUB_OUTPUT.
+          set +e
           BASE_TAG=$(git describe --tags --abbrev=0 --match 'go[0-9]*.[0-9]*.[0-9]*' --exclude '*-*' HEAD)
+          DESCRIBE_STATUS=$?
+          set -e
+          if [ "${DESCRIBE_STATUS}" -ne 0 ] || [ -z "${BASE_TAG}" ]; then
+            echo "rebase_success=false" >> "$GITHUB_OUTPUT"
+            echo "Failed to determine base upstream tag matching pattern 'goX.Y.Z' from HEAD."
+            echo "Ensure the current branch history contains a reachable go release tag."
+            exit 0
+          fi
           echo "Base upstream tag: ${BASE_TAG}"
 
           # Collect all atomix commits on top of the base tag (oldest first).


### PR DESCRIPTION
### Problem

The `watch-upstream.yml` workflow only cherry-picked the **latest single commit** from the atomix branch when rebasing onto a new upstream Go release:

```bash
ATOMIX_COMMIT=$(git log --oneline --no-merges -1 --format="%H")
git cherry-pick "$ATOMIX_COMMIT"
```

The atomix branch has **multiple layered commits** on top of upstream (compiler intrinsics, CI workflows, etc.). Cherry-picking just the top commit fails because it depends on definitions introduced in earlier commits. This caused the automated rebase onto Go 1.25.7 to fail with merge conflicts (issue #2).

### Fix

Replace the single-commit cherry-pick with multi-commit support:

1. **`git describe --tags --abbrev=0 --match 'go[0-9]*.[0-9]*.[0-9]*' --exclude '*-*' HEAD`** — finds the upstream base tag the atomix branch forked from
2. **`git rev-list --no-merges --reverse "${BASE_TAG}..HEAD"`** — collects all atomix commits in chronological order
3. **`git cherry-pick "${ATOMIX_COMMITS[@]}"`** — cherry-picks all of them onto the new upstream tag

Also removes the manual `VERSION` file update (unnecessary since the upstream tag already has the correct VERSION).

### Validation

- Already applied on `release-branch.go1.25-atomix` — all 5 atomix commits rebased cleanly onto `go1.25.7`
- SSA regeneration completed with no diffs
- CI successfully built and tagged `go1.25.7-atomix`
- Verified `git describe` logic on both `release-branch.go1.25-atomix` (base: `go1.25.6`) and `atomix-1.25.7` (base: `go1.25.7`)

Fixes #2
